### PR TITLE
Change Server to start/stop from create/destroy

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -41,6 +41,11 @@ class EventRPCServerCreated extends EventRPCServer {}
 class EventRPCServerDestroy extends EventRPCServer {}
 
 class EventRPCServerDestroyed extends EventRPCServer {}
+class EventRPCServerStart extends EventRPCServer {}
+class EventRPCServerStarted extends EventRPCServer {}
+class EventRPCServerStopping extends EventRPCServer {}
+
+class EventRPCServerStopped extends EventRPCServer {}
 
 class EventRPCServerError extends EventRPCServer<Error> {}
 
@@ -82,4 +87,8 @@ export {
   EventRPCServerDestroyed,
   EventRPCServerError,
   EventRPCConnectionError,
+  EventRPCServerStopping,
+  EventRPCServerStopped,
+  EventRPCServerStart,
+  EventRPCServerStarted,
 };

--- a/tests/RPC.test.ts
+++ b/tests/RPC.test.ts
@@ -62,7 +62,7 @@ describe('RPC', () => {
           });
         };
       }
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -107,7 +107,7 @@ describe('RPC', () => {
       expect(callerInterface.meta?.result).toBe('some leading data');
       expect(await outputResult).toStrictEqual(values);
       await pipeProm;
-      await rpcServer.destroy();
+      await rpcServer.stop();
       await rpcClient.destroy();
     },
   );
@@ -163,7 +163,7 @@ describe('RPC', () => {
       };
     }
 
-    const rpcServer = await RPCServer.createRPCServer({
+    const rpcServer = await RPCServer.startRPCServer({
       manifest: {
         testMethod: new TestMethod({}),
       },
@@ -195,7 +195,7 @@ describe('RPC', () => {
       }),
     ).rejects.toThrow(rpcErrors.ErrorRPCRemote);
 
-    await rpcServer.destroy();
+    await rpcServer.stop();
     await rpcClient.destroy();
   });
   testProp(
@@ -216,7 +216,7 @@ describe('RPC', () => {
           yield* input;
         };
       }
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -253,7 +253,7 @@ describe('RPC', () => {
       const result = await reader.read();
       expect(result.value).toBeUndefined();
       expect(result.done).toBeTrue();
-      await rpcServer.destroy();
+      await rpcServer.stop();
       await rpcClient.destroy();
     },
   );
@@ -276,7 +276,7 @@ describe('RPC', () => {
         };
       }
 
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -309,7 +309,7 @@ describe('RPC', () => {
         outputs.push(num);
       }
       expect(outputs.length).toEqual(value);
-      await rpcServer.destroy();
+      await rpcServer.stop();
       await rpcClient.destroy();
     },
   );
@@ -334,7 +334,7 @@ describe('RPC', () => {
         };
       }
 
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -368,7 +368,7 @@ describe('RPC', () => {
       await writer.close();
       const expectedResult = values.reduce((p, c) => p + c);
       await expect(output).resolves.toEqual(expectedResult);
-      await rpcServer.destroy();
+      await rpcServer.stop();
       await rpcClient.destroy();
     },
   );
@@ -386,7 +386,7 @@ describe('RPC', () => {
           return input;
         };
       }
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -414,7 +414,7 @@ describe('RPC', () => {
 
       const result = await rpcClient.methods.testMethod(value);
       expect(result).toStrictEqual(value);
-      await rpcServer.destroy();
+      await rpcServer.stop();
       await rpcClient.destroy();
     },
   );
@@ -441,7 +441,7 @@ describe('RPC', () => {
         };
       }
 
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -472,7 +472,7 @@ describe('RPC', () => {
       expect(rejection).toMatchObject({ code: -32006 });
 
       // Cleanup
-      await rpcServer.destroy();
+      await rpcServer.stop();
       await rpcClient.destroy();
     },
   );
@@ -500,7 +500,7 @@ describe('RPC', () => {
         };
       }
 
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -526,7 +526,7 @@ describe('RPC', () => {
       await expect(callProm).rejects.toBeInstanceOf(rpcErrors.ErrorRPCRemote);
       await expect(callProm).rejects.not.toHaveProperty('cause.stack');
 
-      await rpcServer.destroy();
+      await rpcServer.stop();
       await rpcClient.destroy();
     },
   );
@@ -562,7 +562,7 @@ describe('RPC', () => {
         }),
       };
     });
-    const rpcServer = await RPCServer.createRPCServer({
+    const rpcServer = await RPCServer.startRPCServer({
       manifest: {
         testMethod: new TestMethod({}),
       },
@@ -599,7 +599,7 @@ describe('RPC', () => {
     await expect(reader.read()).toReject();
     await expect(writer.closed).toReject();
     await expect(reader.closed).toReject();
-    await expect(rpcServer.destroy(false)).toResolve();
+    await expect(rpcServer.stop(false)).toResolve();
     await rpcClient.destroy();
   });
   testProp(
@@ -634,7 +634,7 @@ describe('RPC', () => {
       }
       const testMethodInstance = new TestMethod({});
       // Set up a client and server with matching timeout settings
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: testMethodInstance,
         },
@@ -690,7 +690,7 @@ describe('RPC', () => {
         'Timed out waiting for header',
       );
 
-      await rpcServer.destroy();
+      await rpcServer.stop();
       await rpcClient.destroy();
     },
   );
@@ -725,7 +725,7 @@ describe('RPC', () => {
       }
 
       // Create an instance of the RPC server with a shorter timeout
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: { testMethod: new TestMethod({}) },
         logger,
         idGen,
@@ -769,7 +769,7 @@ describe('RPC', () => {
       );
 
       // Cleanup
-      await rpcServer.destroy();
+      await rpcServer.stop();
       await rpcClient.destroy();
     },
     { numRuns: 1 },
@@ -799,7 +799,7 @@ describe('RPC', () => {
         };
       }
       // Set up a client and server with matching timeout settings
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -835,7 +835,7 @@ describe('RPC', () => {
       await expect(writer.write(value)).toResolve();
       await expect(reader.read()).toReject();
 
-      await rpcServer.destroy();
+      await rpcServer.stop();
       await rpcClient.destroy();
     },
     { numRuns: 1 },
@@ -867,7 +867,7 @@ describe('RPC', () => {
         };
       }
 
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: { testMethod: new TestMethod({}) },
         logger,
         idGen,
@@ -921,7 +921,7 @@ describe('RPC', () => {
       callerTimer.cancel();
 
       // Expect neither to time out and verify that they can still handle other operations #TODO
-      await rpcServer.destroy(true);
+      await rpcServer.stop(true);
       await rpcClient.destroy();
     },
     { numRuns: 1 },
@@ -949,7 +949,7 @@ describe('RPC', () => {
           throw error;
         };
       }
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -987,7 +987,7 @@ describe('RPC', () => {
       const { code, message, data } = deserializedError as ErrorRPCRemote<any>;
       expect(code).toBe(-32006);
 
-      await rpcServer.destroy();
+      await rpcServer.stop();
       await rpcClient.destroy();
     },
   );
@@ -1013,7 +1013,7 @@ describe('RPC', () => {
           throw error;
         };
       }
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -1054,7 +1054,7 @@ describe('RPC', () => {
       expect(code).toBe(-32006);
       expect(data).toBe(undefined);
 
-      await rpcServer.destroy();
+      await rpcServer.stop();
       await rpcClient.destroy();
     },
   );

--- a/tests/RPCServer.test.ts
+++ b/tests/RPCServer.test.ts
@@ -85,7 +85,7 @@ describe(`${RPCServer.name}`, () => {
         };
       }
 
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestHandler({}),
         },
@@ -100,7 +100,7 @@ describe(`${RPCServer.name}`, () => {
       };
       rpcServer.handleStream(readWriteStream);
       await outputResult;
-      await rpcServer.destroy();
+      await rpcServer.stop();
     },
     { numRuns: 1 },
   );
@@ -122,7 +122,7 @@ describe(`${RPCServer.name}`, () => {
           }
         };
       }
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -137,7 +137,7 @@ describe(`${RPCServer.name}`, () => {
       };
       rpcServer.handleStream(readWriteStream);
       await outputResult;
-      await rpcServer.destroy();
+      await rpcServer.stop();
     },
   );
   testProp(
@@ -159,7 +159,7 @@ describe(`${RPCServer.name}`, () => {
           return count;
         };
       }
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -174,7 +174,7 @@ describe(`${RPCServer.name}`, () => {
       };
       rpcServer.handleStream(readWriteStream);
       await outputResult;
-      await rpcServer.destroy();
+      await rpcServer.stop();
     },
   );
   testProp(
@@ -191,7 +191,7 @@ describe(`${RPCServer.name}`, () => {
           }
         };
       }
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -206,7 +206,7 @@ describe(`${RPCServer.name}`, () => {
       };
       rpcServer.handleStream(readWriteStream);
       await outputResult;
-      await rpcServer.destroy();
+      await rpcServer.stop();
     },
   );
   testProp(
@@ -219,7 +219,7 @@ describe(`${RPCServer.name}`, () => {
           return input;
         };
       }
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -234,7 +234,7 @@ describe(`${RPCServer.name}`, () => {
       };
       rpcServer.handleStream(readWriteStream);
       await outputResult;
-      await rpcServer.destroy();
+      await rpcServer.stop();
     },
   );
   testProp(
@@ -261,7 +261,7 @@ describe(`${RPCServer.name}`, () => {
         };
       }
 
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod(container),
         },
@@ -276,7 +276,7 @@ describe(`${RPCServer.name}`, () => {
       };
       rpcServer.handleStream(readWriteStream);
       await outputResult;
-      await rpcServer.destroy();
+      await rpcServer.stop();
     },
   );
   testProp(
@@ -305,7 +305,7 @@ describe(`${RPCServer.name}`, () => {
           }
         };
       }
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -321,7 +321,7 @@ describe(`${RPCServer.name}`, () => {
       };
       rpcServer.handleStream(readWriteStream);
       await outputResult;
-      await rpcServer.destroy();
+      await rpcServer.stop();
       expect(handledMeta).toBe(meta);
     },
   );
@@ -340,7 +340,7 @@ describe(`${RPCServer.name}`, () => {
         }
       };
     }
-    const rpcServer = await RPCServer.createRPCServer({
+    const rpcServer = await RPCServer.startRPCServer({
       manifest: {
         testMethod: new TestMethod({}),
       },
@@ -377,7 +377,7 @@ describe(`${RPCServer.name}`, () => {
     expect(() =>
       rpcUtils.parseJSONRPCResponseError(JSON.parse(lastMessage.toString())),
     ).not.toThrow();
-    await rpcServer.destroy();
+    await rpcServer.stop();
   });
   testProp('handler yields nothing', [specificMessageArb], async (messages) => {
     const stream = rpcTestUtils.messagesToReadableStream(messages);
@@ -393,7 +393,7 @@ describe(`${RPCServer.name}`, () => {
         }
       };
     }
-    const rpcServer = await RPCServer.createRPCServer({
+    const rpcServer = await RPCServer.startRPCServer({
       manifest: {
         testMethod: new TestMethod({}),
       },
@@ -409,7 +409,7 @@ describe(`${RPCServer.name}`, () => {
     rpcServer.handleStream(readWriteStream);
     await outputResult;
     // We're just expecting no errors
-    await rpcServer.destroy();
+    await rpcServer.stop();
   });
   testProp(
     'should send error message',
@@ -421,7 +421,7 @@ describe(`${RPCServer.name}`, () => {
           throw error;
         };
       }
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -448,7 +448,7 @@ describe(`${RPCServer.name}`, () => {
       expect(errorMessage.error.message).toEqual(error.description);
       reject();
       await expect(errorProm).toReject();
-      await rpcServer.destroy();
+      await rpcServer.stop();
     },
   );
   testProp(
@@ -462,7 +462,7 @@ describe(`${RPCServer.name}`, () => {
         };
       }
 
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -489,7 +489,7 @@ describe(`${RPCServer.name}`, () => {
       expect(errorMessage.error.message).toEqual(error.description);
       reject();
       await expect(errorProm).toReject();
-      await rpcServer.destroy();
+      await rpcServer.stop();
     },
   );
   testProp(
@@ -508,7 +508,7 @@ describe(`${RPCServer.name}`, () => {
           }
         };
       }
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -542,7 +542,7 @@ describe(`${RPCServer.name}`, () => {
       rpcUtils.parseJSONRPCResponseError(errorMessage);
       // Check that the handler was cleaned up.
       await expect(handlerEndedProm.p).toResolve();
-      await rpcServer.destroy();
+      await rpcServer.stop();
     },
     { numRuns: 1 },
   );
@@ -568,7 +568,7 @@ describe(`${RPCServer.name}`, () => {
           }
         };
       }
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -616,7 +616,7 @@ describe(`${RPCServer.name}`, () => {
       expect(ctx).toBeDefined();
       expect(ctx?.signal.aborted).toBeTrue();
       expect(ctx?.signal.reason).toBe(readerReason);
-      await rpcServer.destroy();
+      await rpcServer.stop();
     },
     { numRuns: 1 },
   );
@@ -645,7 +645,7 @@ describe(`${RPCServer.name}`, () => {
         };
       },
     );
-    const rpcServer = await RPCServer.createRPCServer({
+    const rpcServer = await RPCServer.startRPCServer({
       manifest: {
         testMethod: new TestMethod({}),
       },
@@ -670,7 +670,7 @@ describe(`${RPCServer.name}`, () => {
         });
       }),
     );
-    await rpcServer.destroy();
+    await rpcServer.stop();
   });
   testProp('reverse middlewares', [specificMessageArb], async (messages) => {
     const stream = rpcTestUtils.messagesToReadableStream(messages);
@@ -695,7 +695,7 @@ describe(`${RPCServer.name}`, () => {
         }),
       };
     });
-    const rpcServer = await RPCServer.createRPCServer({
+    const rpcServer = await RPCServer.startRPCServer({
       manifest: {
         testMethod: new TestMethod({}),
       },
@@ -720,7 +720,7 @@ describe(`${RPCServer.name}`, () => {
         });
       }),
     );
-    await rpcServer.destroy();
+    await rpcServer.stop();
   });
   testProp(
     'forward middleware authentication',
@@ -769,7 +769,7 @@ describe(`${RPCServer.name}`, () => {
           };
         },
       );
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },
@@ -802,7 +802,7 @@ describe(`${RPCServer.name}`, () => {
       expect((await outputResult).toString()).toEqual(
         JSON.stringify(failureMessage),
       );
-      await rpcServer.destroy();
+      await rpcServer.stop();
     },
   );
 
@@ -838,7 +838,7 @@ describe(`${RPCServer.name}`, () => {
       };
     }
 
-    const rpcServer = await RPCServer.createRPCServer({
+    const rpcServer = await RPCServer.startRPCServer({
       manifest: {
         testMethod: new TestHandler({}),
       },
@@ -879,10 +879,10 @@ describe(`${RPCServer.name}`, () => {
 
     await expect(outputResult).toReject();
 
-    await rpcServer.destroy();
+    await rpcServer.stop();
   });
   test('timeout with default time before handler selected', async () => {
-    const rpcServer = await RPCServer.createRPCServer({
+    const rpcServer = await RPCServer.startRPCServer({
       manifest: {},
       handlerTimeoutTime: 100,
       logger,
@@ -906,7 +906,7 @@ describe(`${RPCServer.name}`, () => {
     for await (const [prom] of activeStreams.entries()) {
       await prom;
     }
-    await rpcServer.destroy();
+    await rpcServer.stop();
   });
   test('handler overrides timeout', async () => {
     {
@@ -939,7 +939,7 @@ describe(`${RPCServer.name}`, () => {
           return input;
         };
       }
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testShort: new TestMethodShortTimeout({}),
           testLong: new TestMethodLongTimeout({}),
@@ -982,7 +982,7 @@ describe(`${RPCServer.name}`, () => {
       const ctxLong = await ctxLongProm.p;
       expect(ctxLong.timer.delay).toEqual(50);
       waitProm.resolveP();
-      await rpcServer.destroy();
+      await rpcServer.stop();
     }
   });
   test('duplex handler refreshes timeout when messages are sent', async () => {
@@ -1007,7 +1007,7 @@ describe(`${RPCServer.name}`, () => {
         yield 2;
       };
     }
-    const rpcServer = await RPCServer.createRPCServer({
+    const rpcServer = await RPCServer.startRPCServer({
       manifest: {
         testMethod: new TestHandler({}),
       },
@@ -1050,7 +1050,7 @@ describe(`${RPCServer.name}`, () => {
     ).toBeGreaterThanOrEqual(25);
     stepProm2.resolveP();
     await outputResult;
-    await rpcServer.destroy();
+    await rpcServer.stop();
   });
   test('stream ending cleans up timer and abortSignal', async () => {
     const ctxProm = promise<ContextTimed>();
@@ -1077,7 +1077,7 @@ describe(`${RPCServer.name}`, () => {
         });
       };
     }
-    const rpcServer = await RPCServer.createRPCServer({
+    const rpcServer = await RPCServer.startRPCServer({
       manifest: {
         testMethod: new TestHandler({}),
       },
@@ -1100,12 +1100,12 @@ describe(`${RPCServer.name}`, () => {
     rpcServer.handleStream(readWriteStream);
     const ctx = await ctxProm.p;
     await outputResult;
-    await rpcServer.destroy(false);
+    await rpcServer.stop(false);
     expect(ctx.signal.aborted).toBeTrue();
     expect(ctx.signal.reason).toBeInstanceOf(rpcErrors.ErrorRPCStreamEnded);
     // If the timer has already resolved then it was cancelled
     await expect(ctx.timer).toReject();
-    await rpcServer.destroy();
+    await rpcServer.stop();
   });
   testProp(
     'middleware can update timeout timer',
@@ -1132,7 +1132,7 @@ describe(`${RPCServer.name}`, () => {
             reverse: new TransformStream(),
           };
         });
-      const rpcServer = await RPCServer.createRPCServer({
+      const rpcServer = await RPCServer.startRPCServer({
         manifest: {
           testMethod: new TestMethod({}),
         },


### PR DESCRIPTION
### Description
The goal of this PR is to replace the server create/destroy with start/stop, as logically, starting and stopping makes more sense in Polykey as other layers such as QUIC and WS operate on start/stop.


### Tasks

- [x] 1. Create new events.
- [x] 2. Replace events.
- [x] 3. Refactor function names

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
