### PR TITLE
ToError FromError Protocol Changes

### DIFF
--- a/src/RPCClient.ts
+++ b/src/RPCClient.ts
@@ -469,15 +469,18 @@ class RPCClient<M extends ClientManifest> {
             ...(rpcStream.meta ?? {}),
             command: method,
           };
-          const e: errors.ErrorRPCProtocol<any> = errors.ErrorRPCProtocol.fromJSON(messageValue.error);
+          const e: errors.ErrorRPCProtocol<any> =
+            errors.ErrorRPCProtocol.fromJSON(messageValue.error);
           if (
             e instanceof errors.ErrorRPCRemote &&
             messageValue.error.data != null &&
-            typeof messageValue.error.data === "object" &&
+            typeof messageValue.error.data === 'object' &&
             'cause' in messageValue.error.data
           ) {
             e.metadata = metadata;
-            e.cause = this.toError(JSON.parse(messageValue.error.data.cause as string));
+            e.cause = this.toError(
+              JSON.parse(messageValue.error.data.cause as string),
+            );
           }
           throw e;
         }

--- a/src/RPCServer.ts
+++ b/src/RPCServer.ts
@@ -34,6 +34,7 @@ import * as utils from './utils';
 import * as errors from './errors';
 import * as middleware from './middleware';
 import * as events from './events';
+import { POJO } from '@matrixai/errors';
 
 const cleanupReason = Symbol('CleanupReason');
 
@@ -325,11 +326,8 @@ class RPCServer {
               rpcError = e.toJSON();
             }
             else {
-              rpcError = {
-                code: errors.JSONRPCErrorCode.RPCRemote,
-                message: e?.message ?? '',
-                data: JSON.stringify(this.fromError(e), this.replacer),
-              };
+              rpcError = new errors.ErrorRPCRemote(e?.message).toJSON();
+              (rpcError.data as POJO).cause = JSON.stringify(this.fromError(e), this.replacer);
             }
             const rpcErrorMessage: JSONRPCResponseError = {
               jsonrpc: '2.0',
@@ -588,11 +586,8 @@ class RPCServer {
           rpcError = e.toJSON();
         }
         else {
-          rpcError = {
-            code: errors.JSONRPCErrorCode.RPCRemote,
-            message: e?.message ?? '',
-            data: JSON.stringify(this.fromError(e), this.replacer),
-          };
+          rpcError = new errors.ErrorRPCRemote(e?.message).toJSON();
+          (rpcError.data as POJO).cause = JSON.stringify(this.fromError(e), this.replacer);
         }
         const rpcErrorMessage: JSONRPCResponseError = {
           jsonrpc: '2.0',

--- a/src/RPCServer.ts
+++ b/src/RPCServer.ts
@@ -327,7 +327,18 @@ class RPCServer {
             }
             else {
               rpcError = new errors.ErrorRPCRemote(e?.message).toJSON();
-              (rpcError.data as POJO).cause = JSON.stringify(this.fromError(e), this.replacer);
+              try {
+                (rpcError.data as POJO).cause = JSON.stringify(this.fromError(e), this.replacer);
+              }
+              catch (e) {
+                (rpcError.data as POJO).cause = e;
+                // dispatch error in the case where the thrown value could not be parsed
+                this.dispatchEvent(
+                  new events.RPCErrorEvent({
+                    detail: e,
+                  }),
+                );
+              }
             }
             const rpcErrorMessage: JSONRPCResponseError = {
               jsonrpc: '2.0',
@@ -587,7 +598,18 @@ class RPCServer {
         }
         else {
           rpcError = new errors.ErrorRPCRemote(e?.message).toJSON();
-          (rpcError.data as POJO).cause = JSON.stringify(this.fromError(e), this.replacer);
+          try {
+            (rpcError.data as POJO).cause = JSON.stringify(this.fromError(e), this.replacer);
+          }
+          catch (e) {
+            (rpcError.data as POJO).cause = e;
+            // dispatch error in the case where the thrown value could not be parsed
+            this.dispatchEvent(
+              new events.RPCErrorEvent({
+                detail: e,
+              }),
+            );
+          }
         }
         const rpcErrorMessage: JSONRPCResponseError = {
           jsonrpc: '2.0',

--- a/src/callers/RawCaller.ts
+++ b/src/callers/RawCaller.ts
@@ -1,4 +1,3 @@
-import type { JSONValue } from '../types';
 import Caller from './Caller';
 class RawCaller extends Caller {
   public type: 'RAW' = 'RAW' as const;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,7 +1,6 @@
 import type { Class } from '@matrixai/errors';
-import type { JSONRPCError, JSONValue } from '@/types';
+import type { JSONRPCError } from '@/types';
 import { AbstractError } from '@matrixai/errors';
-import { JSONRPCErrorCode, rpcProtocolErrors } from './utils';
 
 class ErrorRPC<T> extends AbstractError<T> {
   static description = 'RPC Error';
@@ -159,6 +158,50 @@ class ErrorRPCConnectionInternal<T> extends ErrorRPCProtocol<T> {
   code = JSONRPCErrorCode.RPCConnectionInternal;
 }
 
+const enum JSONRPCErrorCode {
+  ParseError = -32700,
+  InvalidRequest = -32600,
+  MethodNotFound = -32601,
+  InvalidParams = -32602,
+  InternalError = -32603,
+  HandlerNotFound = -32000,
+  RPCStopping = -32001,
+  RPCMessageLength = -32003,
+  RPCMissingResponse = -32004,
+  RPCOutputStreamError = -32005,
+  RPCRemote = -32006,
+  RPCStreamEnded = -32007,
+  RPCTimedOut = -32008,
+  RPCConnectionLocal = -32010,
+  RPCConnectionPeer = -32011,
+  RPCConnectionKeepAliveTimeOut = -32012,
+  RPCConnectionInternal = -32013,
+  MissingHeader = -32014,
+  HandlerAborted = -32015,
+  MissingCaller = -32016,
+}
+
+const rpcProtocolErrors = {
+  [JSONRPCErrorCode.RPCRemote]: ErrorRPCRemote,
+  [JSONRPCErrorCode.RPCStopping]: ErrorRPCStopping,
+  [JSONRPCErrorCode.RPCMessageLength]: ErrorRPCMessageLength,
+  [JSONRPCErrorCode.ParseError]: ErrorRPCParse,
+  [JSONRPCErrorCode.InvalidParams]: ErrorRPCInvalidParams,
+  [JSONRPCErrorCode.HandlerNotFound]: ErrorRPCHandlerFailed,
+  [JSONRPCErrorCode.RPCMissingResponse]: ErrorRPCMissingResponse,
+  [JSONRPCErrorCode.RPCOutputStreamError]: ErrorRPCOutputStreamError,
+  [JSONRPCErrorCode.RPCTimedOut]: ErrorRPCTimedOut,
+  [JSONRPCErrorCode.RPCStreamEnded]: ErrorRPCStreamEnded,
+  [JSONRPCErrorCode.RPCConnectionLocal]: ErrorRPCConnectionLocal,
+  [JSONRPCErrorCode.RPCConnectionPeer]: ErrorRPCConnectionPeer,
+  [JSONRPCErrorCode.RPCConnectionKeepAliveTimeOut]:
+  ErrorRPCConnectionKeepAliveTimeOut,
+  [JSONRPCErrorCode.RPCConnectionInternal]: ErrorRPCConnectionInternal,
+  [JSONRPCErrorCode.MissingHeader]: ErrorMissingHeader,
+  [JSONRPCErrorCode.HandlerAborted]: ErrorRPCHandlerFailed,
+  [JSONRPCErrorCode.MissingCaller]: ErrorMissingCaller,
+};
+
 export {
   ErrorRPC,
   ErrorRPCServer,
@@ -185,4 +228,5 @@ export {
   ErrorRPCCallerFailed,
   ErrorMissingCaller,
   JSONRPCErrorCode,
+  rpcProtocolErrors,
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -41,13 +41,13 @@ abstract class ErrorRPCProtocol<T> extends ErrorRPC<T> {
       typeof json.message !== 'string' ||
       typeof json.data !== 'object'
     ) {
-      throw new TypeError(`Cannot decode JSON to ${this.name}`);
+      return new ErrorRPCUnknown<T>(`Cannot decode JSON to ${this.name}`) as InstanceType<T>;
     }
 
     const errorC = rpcProtocolErrors[json.code];
 
     if (errorC == null) {
-      throw new TypeError(`Cannot decode JSON to ${this.name}`);
+      return new ErrorRPCUnknown<T>(`Unknown error.code found on RPC message`) as InstanceType<T>;
     }
 
     const e: InstanceType<T> = new errorC(json.message);
@@ -168,6 +168,11 @@ class ErrorRPCConnectionInternal<T> extends ErrorRPCProtocol<T> {
   code = JSONRPCErrorCode.RPCConnectionInternal;
 }
 
+class ErrorRPCUnknown<T> extends ErrorRPCProtocol<T> {
+  static description = 'RPC Unknown Error';
+  code = 0;
+}
+
 export {
   ErrorRPC,
   ErrorRPCServer,
@@ -193,4 +198,5 @@ export {
   ErrorHandlerAborted,
   ErrorRPCCallerFailed,
   ErrorMissingCaller,
+  ErrorRPCUnknown
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,4 @@
-import type { Class, POJO } from '@matrixai/errors';
+import type { Class } from '@matrixai/errors';
 import type { JSONRPCError, JSONValue } from '@/types';
 import { AbstractError } from '@matrixai/errors';
 
@@ -31,22 +31,24 @@ abstract class ErrorRPCProtocol<T> extends ErrorRPC<T> {
   static error = 'RPC Protocol Error';
   code: number;
 
-  public static fromJSON<T extends Class<any>>(
-    json: any,
-  ): InstanceType<T> {
+  public static fromJSON<T extends Class<any>>(json: any): InstanceType<T> {
     if (
       typeof json !== 'object' ||
       typeof json.code !== 'number' ||
       typeof json.message !== 'string' ||
       typeof json.data !== 'object'
     ) {
-      return new ErrorRPCUnknown<T>(`Cannot decode JSON to ${this.name}`) as InstanceType<T>;
+      return new ErrorRPCUnknown<T>(
+        `Cannot decode JSON to ${this.name}`,
+      ) as InstanceType<T>;
     }
 
     const errorC = rpcProtocolErrors[json.code];
 
     if (errorC == null) {
-      return new ErrorRPCUnknown<T>(`Unknown error.code found on RPC message`) as InstanceType<T>;
+      return new ErrorRPCUnknown<T>(
+        `Unknown error.code found on RPC message`,
+      ) as InstanceType<T>;
     }
 
     const e: InstanceType<T> = new errorC(json.message);
@@ -70,7 +72,7 @@ abstract class ErrorRPCProtocol<T> extends ErrorRPC<T> {
         data: this.data,
         stack: this.stack,
       },
-    }
+    };
   }
 }
 
@@ -83,7 +85,6 @@ class ErrorRPCInvalidParams<T> extends ErrorRPCProtocol<T> {
   static description = 'Invalid paramaters provided to RPC';
   code = JSONRPCErrorCode.InvalidParams;
 }
-
 
 class ErrorRPCStopping<T> extends ErrorRPCProtocol<T> {
   static description = 'RPC is stopping';
@@ -209,7 +210,7 @@ const rpcProtocolErrors = {
   [JSONRPCErrorCode.RPCConnectionLocal]: ErrorRPCConnectionLocal,
   [JSONRPCErrorCode.RPCConnectionPeer]: ErrorRPCConnectionPeer,
   [JSONRPCErrorCode.RPCConnectionKeepAliveTimeOut]:
-  ErrorRPCConnectionKeepAliveTimeOut,
+    ErrorRPCConnectionKeepAliveTimeOut,
   [JSONRPCErrorCode.RPCConnectionInternal]: ErrorRPCConnectionInternal,
   [JSONRPCErrorCode.MissingHeader]: ErrorMissingHeader,
   [JSONRPCErrorCode.HandlerAborted]: ErrorRPCHandlerFailed,
@@ -243,5 +244,5 @@ export {
   ErrorMissingCaller,
   ErrorRPCUnknown,
   JSONRPCErrorCode,
-  rpcProtocolErrors
+  rpcProtocolErrors,
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,7 +1,6 @@
 import type { Class, POJO } from '@matrixai/errors';
 import type { JSONRPCError, JSONValue } from '@/types';
 import { AbstractError } from '@matrixai/errors';
-import { JSONRPCErrorCode, rpcProtocolErrors } from './utils';
 
 class ErrorRPC<T> extends AbstractError<T> {
   static description = 'RPC Error';
@@ -173,6 +172,50 @@ class ErrorRPCUnknown<T> extends ErrorRPCProtocol<T> {
   code = 0;
 }
 
+const enum JSONRPCErrorCode {
+  ParseError = -32700,
+  InvalidRequest = -32600,
+  MethodNotFound = -32601,
+  InvalidParams = -32602,
+  InternalError = -32603,
+  HandlerNotFound = -32000,
+  RPCStopping = -32001,
+  RPCMessageLength = -32003,
+  RPCMissingResponse = -32004,
+  RPCOutputStreamError = -32005,
+  RPCRemote = -32006,
+  RPCStreamEnded = -32007,
+  RPCTimedOut = -32008,
+  RPCConnectionLocal = -32010,
+  RPCConnectionPeer = -32011,
+  RPCConnectionKeepAliveTimeOut = -32012,
+  RPCConnectionInternal = -32013,
+  MissingHeader = -32014,
+  HandlerAborted = -32015,
+  MissingCaller = -32016,
+}
+
+const rpcProtocolErrors = {
+  [JSONRPCErrorCode.RPCRemote]: ErrorRPCRemote,
+  [JSONRPCErrorCode.RPCStopping]: ErrorRPCStopping,
+  [JSONRPCErrorCode.RPCMessageLength]: ErrorRPCMessageLength,
+  [JSONRPCErrorCode.ParseError]: ErrorRPCParse,
+  [JSONRPCErrorCode.InvalidParams]: ErrorRPCInvalidParams,
+  [JSONRPCErrorCode.HandlerNotFound]: ErrorRPCHandlerFailed,
+  [JSONRPCErrorCode.RPCMissingResponse]: ErrorRPCMissingResponse,
+  [JSONRPCErrorCode.RPCOutputStreamError]: ErrorRPCOutputStreamError,
+  [JSONRPCErrorCode.RPCTimedOut]: ErrorRPCTimedOut,
+  [JSONRPCErrorCode.RPCStreamEnded]: ErrorRPCStreamEnded,
+  [JSONRPCErrorCode.RPCConnectionLocal]: ErrorRPCConnectionLocal,
+  [JSONRPCErrorCode.RPCConnectionPeer]: ErrorRPCConnectionPeer,
+  [JSONRPCErrorCode.RPCConnectionKeepAliveTimeOut]:
+  ErrorRPCConnectionKeepAliveTimeOut,
+  [JSONRPCErrorCode.RPCConnectionInternal]: ErrorRPCConnectionInternal,
+  [JSONRPCErrorCode.MissingHeader]: ErrorMissingHeader,
+  [JSONRPCErrorCode.HandlerAborted]: ErrorRPCHandlerFailed,
+  [JSONRPCErrorCode.MissingCaller]: ErrorMissingCaller,
+};
+
 export {
   ErrorRPC,
   ErrorRPCServer,
@@ -198,5 +241,7 @@ export {
   ErrorHandlerAborted,
   ErrorRPCCallerFailed,
   ErrorMissingCaller,
-  ErrorRPCUnknown
+  ErrorRPCUnknown,
+  JSONRPCErrorCode,
+  rpcProtocolErrors
 };

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,4 +1,3 @@
-import type RPCServer from './RPCServer';
 import type {
   ErrorRPCConnectionLocal,
   ErrorRPCConnectionPeer,

--- a/src/handlers/ClientHandler.ts
+++ b/src/handlers/ClientHandler.ts
@@ -9,10 +9,12 @@ abstract class ClientHandler<
   Output extends JSONValue = JSONValue,
 > extends Handler<Container, Input, Output> {
   public async handle(
+    /* eslint-disable */
     input: AsyncIterableIterator<Input>,
     cancel: (reason?: any) => void,
     meta: Record<string, JSONValue> | undefined,
     ctx: ContextTimed,
+    /* eslint-disable */
   ): Promise<Output> {
     throw new ErrorRPCMethodNotImplemented();
   }

--- a/src/handlers/DuplexHandler.ts
+++ b/src/handlers/DuplexHandler.ts
@@ -14,10 +14,12 @@ abstract class DuplexHandler<
    * `finally` block and check the abort signal for potential errors.
    */
   public async *handle(
+    /* eslint-disable */
     input: AsyncIterableIterator<Input>,
     cancel: (reason?: any) => void,
     meta: Record<string, JSONValue> | undefined,
     ctx: ContextTimed,
+    /* eslint-disable */
   ): AsyncIterableIterator<Output> {
     throw new ErrorRPCMethodNotImplemented('This method must be overwrtitten.');
   }

--- a/src/handlers/RawHandler.ts
+++ b/src/handlers/RawHandler.ts
@@ -8,10 +8,12 @@ abstract class RawHandler<
   Container extends ContainerType = ContainerType,
 > extends Handler<Container> {
   public async handle(
+    /* eslint-disable */
     input: [JSONRPCRequest, ReadableStream<Uint8Array>],
     cancel: (reason?: any) => void,
     meta: Record<string, JSONValue> | undefined,
     ctx: ContextTimed,
+    /* eslint-disable */
   ): Promise<[JSONValue, ReadableStream<Uint8Array>]> {
     throw new ErrorRPCMethodNotImplemented('This method must be overridden');
   }

--- a/src/handlers/ServerHandler.ts
+++ b/src/handlers/ServerHandler.ts
@@ -9,10 +9,12 @@ abstract class ServerHandler<
   Output extends JSONValue = JSONValue,
 > extends Handler<Container, Input, Output> {
   public async *handle(
+    /* eslint-disable */
     input: Input,
     cancel: (reason?: any) => void,
     meta: Record<string, JSONValue> | undefined,
     ctx: ContextTimed,
+    /* eslint-disable */
   ): AsyncIterableIterator<Output> {
     throw new ErrorRPCMethodNotImplemented('This method must be overridden');
   }

--- a/src/handlers/UnaryHandler.ts
+++ b/src/handlers/UnaryHandler.ts
@@ -9,10 +9,12 @@ abstract class UnaryHandler<
   Output extends JSONValue = JSONValue,
 > extends Handler<Container, Input, Output> {
   public async handle(
+    /* eslint-disable */
     input: Input,
     cancel: (reason?: any) => void,
     meta: Record<string, JSONValue> | undefined,
     ctx: ContextTimed,
+    /* eslint-disable */
   ): Promise<Output> {
     throw new ErrorRPCMethodNotImplemented('This method must be overridden');
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,6 @@ import type { ServerCaller } from './callers';
 import type { ClientCaller } from './callers';
 import type { UnaryCaller } from './callers';
 import type Handler from './handlers/Handler';
-import type { ErrorRPC } from './errors';
 
 /**
  * This is the type for the IdGenFunction. It is used to generate the request
@@ -350,7 +349,7 @@ type HandlerTypes<T> = T extends Handler<
 
 type FromError = (error: any) => JSONValue;
 
-type ToError = (errorData: JSONValue, metadata: JSONValue) => any;
+type ToError = (errorData: JSONValue) => any;
 
 export type {
   IdGen,

--- a/src/types.ts
+++ b/src/types.ts
@@ -375,10 +375,11 @@ export type {
   ClientManifest,
   HandlerType,
   MapCallers,
+  Opaque,
   JSONValue,
   POJO,
   PromiseDeconstructed,
   HandlerTypes,
   FromError,
-  ToError
+  ToError,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -348,6 +348,10 @@ type HandlerTypes<T> = T extends Handler<
     }
   : never;
 
+type FromError = (error: any) => JSONValue;
+
+type ToError = (errorData: JSONValue, metadata: JSONValue) => any;
+
 export type {
   IdGen,
   JSONRPCRequestMessage,
@@ -376,4 +380,6 @@ export type {
   POJO,
   PromiseDeconstructed,
   HandlerTypes,
+  FromError,
+  ToError
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -215,6 +215,7 @@ function parseJSONRPCMessage<T extends JSONValue>(
  * Serializes an Error instance into a JSONValue object suitable for RPC.
  * @param {Error} error - The Error instance to serialize.
  * @returns {JSONValue} The serialized ErrorRPC instance.
+ * @throws {TypeError} If the error is an instance of {@link Symbol}, {@link BigInt} or {@link Function}.
  */
 function fromError(error: any): JSONValue {
   // TODO: Linked-List traversal must be done iteractively rather than recusively to prevent stack overflow.
@@ -315,11 +316,9 @@ const filterSensitive = (keyToRemove) => {
 
 /**
  * Deserializes an error response object into an ErrorRPCRemote instance.
- * @param {any} errorResponse - The error response object.
- * @returns {ErrorRPCRemote<any>} The deserialized ErrorRPCRemote instance.
- * @throws {TypeError} If the errorResponse object is invalid.
+ * @param {JSONValue} errorData - The error data object.
+ * @returns {any} The deserialized error.
  */
-
 function toError(errorData: JSONValue): any {
   // If the value is an error then reconstruct it
   if (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,27 +16,7 @@ import type {
 import { TransformStream } from 'stream/web';
 import { JSONParser } from '@streamparser/json';
 import { AbstractError } from '@matrixai/errors';
-import {
-  ErrorRPCRemote,
-  ErrorRPC,
-  ErrorRPCConnectionInternal,
-  ErrorRPCStopping,
-  ErrorRPCMessageLength,
-  ErrorRPCParse,
-  ErrorRPCHandlerFailed,
-  ErrorRPCMissingResponse,
-  ErrorRPCOutputStreamError,
-  ErrorRPCTimedOut,
-  ErrorRPCStreamEnded,
-  ErrorRPCConnectionLocal,
-  ErrorRPCConnectionPeer,
-  ErrorRPCConnectionKeepAliveTimeOut,
-  ErrorMissingHeader,
-  ErrorMissingCaller,
-  ErrorRPCProtocol,
-  ErrorRPCInvalidParams,
-} from './errors';
-import * as rpcErrors from './errors';
+import * as errors from './errors';
 
 // Importing PK funcs and utils which are essential for RPC
 function isObject(o: unknown): o is object {
@@ -63,13 +43,13 @@ function parseJSONRPCRequest<T extends JSONValue>(
   message: unknown,
 ): JSONRPCRequest<T> {
   if (!isObject(message)) {
-    throw new rpcErrors.ErrorRPCParse('must be a JSON POJO');
+    throw new errors.ErrorRPCParse('must be a JSON POJO');
   }
   if (!('method' in message)) {
-    throw new rpcErrors.ErrorRPCParse('`method` property must be defined');
+    throw new errors.ErrorRPCParse('`method` property must be defined');
   }
   if (typeof message.method !== 'string') {
-    throw new rpcErrors.ErrorRPCParse('`method` property must be a string');
+    throw new errors.ErrorRPCParse('`method` property must be a string');
   }
   // If ('params' in message && !utils.isObject(message.params)) {
   //   throw new rpcErrors.ErrorRPCParse('`params` property must be a POJO');
@@ -82,14 +62,14 @@ function parseJSONRPCRequestMessage<T extends JSONValue>(
 ): JSONRPCRequestMessage<T> {
   const jsonRequest = parseJSONRPCRequest(message);
   if (!('id' in jsonRequest)) {
-    throw new rpcErrors.ErrorRPCParse('`id` property must be defined');
+    throw new errors.ErrorRPCParse('`id` property must be defined');
   }
   if (
     typeof jsonRequest.id !== 'string' &&
     typeof jsonRequest.id !== 'number' &&
     jsonRequest.id !== null
   ) {
-    throw new rpcErrors.ErrorRPCParse(
+    throw new errors.ErrorRPCParse(
       '`id` property must be a string, number or null',
     );
   }
@@ -101,7 +81,7 @@ function parseJSONRPCRequestNotification<T extends JSONValue>(
 ): JSONRPCRequestNotification<T> {
   const jsonRequest = parseJSONRPCRequest(message);
   if ('id' in jsonRequest) {
-    throw new rpcErrors.ErrorRPCParse('`id` property must not be defined');
+    throw new errors.ErrorRPCParse('`id` property must not be defined');
   }
   return jsonRequest as JSONRPCRequestNotification<T>;
 }
@@ -110,26 +90,26 @@ function parseJSONRPCResponseResult<T extends JSONValue>(
   message: unknown,
 ): JSONRPCResponseResult<T> {
   if (!isObject(message)) {
-    throw new rpcErrors.ErrorRPCParse('must be a JSON POJO');
+    throw new errors.ErrorRPCParse('must be a JSON POJO');
   }
   if (!('result' in message)) {
-    throw new rpcErrors.ErrorRPCParse('`result` property must be defined');
+    throw new errors.ErrorRPCParse('`result` property must be defined');
   }
   if ('error' in message) {
-    throw new rpcErrors.ErrorRPCParse('`error` property must not be defined');
+    throw new errors.ErrorRPCParse('`error` property must not be defined');
   }
   // If (!utils.isObject(message.result)) {
   //   throw new rpcErrors.ErrorRPCParse('`result` property must be a POJO');
   // }
   if (!('id' in message)) {
-    throw new rpcErrors.ErrorRPCParse('`id` property must be defined');
+    throw new errors.ErrorRPCParse('`id` property must be defined');
   }
   if (
     typeof message.id !== 'string' &&
     typeof message.id !== 'number' &&
     message.id !== null
   ) {
-    throw new rpcErrors.ErrorRPCParse(
+    throw new errors.ErrorRPCParse(
       '`id` property must be a string, number or null',
     );
   }
@@ -138,24 +118,24 @@ function parseJSONRPCResponseResult<T extends JSONValue>(
 
 function parseJSONRPCResponseError(message: unknown): JSONRPCResponseError {
   if (!isObject(message)) {
-    throw new rpcErrors.ErrorRPCParse('must be a JSON POJO');
+    throw new errors.ErrorRPCParse('must be a JSON POJO');
   }
   if ('result' in message) {
-    throw new rpcErrors.ErrorRPCParse('`result` property must not be defined');
+    throw new errors.ErrorRPCParse('`result` property must not be defined');
   }
   if (!('error' in message)) {
-    throw new rpcErrors.ErrorRPCParse('`error` property must be defined');
+    throw new errors.ErrorRPCParse('`error` property must be defined');
   }
   parseJSONRPCError(message.error);
   if (!('id' in message)) {
-    throw new rpcErrors.ErrorRPCParse('`id` property must be defined');
+    throw new errors.ErrorRPCParse('`id` property must be defined');
   }
   if (
     typeof message.id !== 'string' &&
     typeof message.id !== 'number' &&
     message.id !== null
   ) {
-    throw new rpcErrors.ErrorRPCParse(
+    throw new errors.ErrorRPCParse(
       '`id` property must be a string, number or null',
     );
   }
@@ -164,19 +144,19 @@ function parseJSONRPCResponseError(message: unknown): JSONRPCResponseError {
 
 function parseJSONRPCError(message: unknown): JSONRPCError {
   if (!isObject(message)) {
-    throw new rpcErrors.ErrorRPCParse('must be a JSON POJO');
+    throw new errors.ErrorRPCParse('must be a JSON POJO');
   }
   if (!('code' in message)) {
-    throw new rpcErrors.ErrorRPCParse('`code` property must be defined');
+    throw new errors.ErrorRPCParse('`code` property must be defined');
   }
   if (typeof message.code !== 'number') {
-    throw new rpcErrors.ErrorRPCParse('`code` property must be a number');
+    throw new errors.ErrorRPCParse('`code` property must be a number');
   }
   if (!('message' in message)) {
-    throw new rpcErrors.ErrorRPCParse('`message` property must be defined');
+    throw new errors.ErrorRPCParse('`message` property must be defined');
   }
   if (typeof message.message !== 'string') {
-    throw new rpcErrors.ErrorRPCParse('`message` property must be a string');
+    throw new errors.ErrorRPCParse('`message` property must be a string');
   }
   // If ('data' in message && !utils.isObject(message.data)) {
   //   throw new rpcErrors.ErrorRPCParse('`data` property must be a POJO');
@@ -188,7 +168,7 @@ function parseJSONRPCResponse<T extends JSONValue>(
   message: unknown,
 ): JSONRPCResponse<T> {
   if (!isObject(message)) {
-    throw new rpcErrors.ErrorRPCParse('must be a JSON POJO');
+    throw new errors.ErrorRPCParse('must be a JSON POJO');
   }
   try {
     return parseJSONRPCResponseResult(message);
@@ -200,7 +180,7 @@ function parseJSONRPCResponse<T extends JSONValue>(
   } catch (e) {
     // Do nothing
   }
-  throw new rpcErrors.ErrorRPCParse(
+  throw new errors.ErrorRPCParse(
     'structure did not match a `JSONRPCResponse`',
   );
 }
@@ -209,13 +189,13 @@ function parseJSONRPCMessage<T extends JSONValue>(
   message: unknown,
 ): JSONRPCMessage<T> {
   if (!isObject(message)) {
-    throw new rpcErrors.ErrorRPCParse('must be a JSON POJO');
+    throw new errors.ErrorRPCParse('must be a JSON POJO');
   }
   if (!('jsonrpc' in message)) {
-    throw new rpcErrors.ErrorRPCParse('`jsonrpc` property must be defined');
+    throw new errors.ErrorRPCParse('`jsonrpc` property must be defined');
   }
   if (message.jsonrpc !== '2.0') {
-    throw new rpcErrors.ErrorRPCParse(
+    throw new errors.ErrorRPCParse(
       '`jsonrpc` property must be a string of "2.0"',
     );
   }
@@ -229,7 +209,7 @@ function parseJSONRPCMessage<T extends JSONValue>(
   } catch {
     // Do nothing
   }
-  throw new rpcErrors.ErrorRPCParse(
+  throw new errors.ErrorRPCParse(
     'Message structure did not match a `JSONRPCMessage`',
   );
 }
@@ -307,7 +287,7 @@ const filterSensitive = (keyToRemove) => {
     }
 
     if (key !== 'code') {
-      if (value instanceof rpcErrors.ErrorRPCProtocol) {
+      if (value instanceof errors.ErrorRPCProtocol) {
         return {
           code: value.code,
           message: value.message,
@@ -330,50 +310,6 @@ const filterSensitive = (keyToRemove) => {
 
     return value;
   };
-};
-
-const enum JSONRPCErrorCode {
-  ParseError = -32700,
-  InvalidRequest = -32600,
-  MethodNotFound = -32601,
-  InvalidParams = -32602,
-  InternalError = -32603,
-  HandlerNotFound = -32000,
-  RPCStopping = -32001,
-  RPCMessageLength = -32003,
-  RPCMissingResponse = -32004,
-  RPCOutputStreamError = -32005,
-  RPCRemote = -32006,
-  RPCStreamEnded = -32007,
-  RPCTimedOut = -32008,
-  RPCConnectionLocal = -32010,
-  RPCConnectionPeer = -32011,
-  RPCConnectionKeepAliveTimeOut = -32012,
-  RPCConnectionInternal = -32013,
-  MissingHeader = -32014,
-  HandlerAborted = -32015,
-  MissingCaller = -32016,
-}
-
-const rpcProtocolErrors = {
-  [JSONRPCErrorCode.RPCRemote]: ErrorRPCRemote,
-  [JSONRPCErrorCode.RPCStopping]: ErrorRPCStopping,
-  [JSONRPCErrorCode.RPCMessageLength]: ErrorRPCMessageLength,
-  [JSONRPCErrorCode.ParseError]: ErrorRPCParse,
-  [JSONRPCErrorCode.InvalidParams]: ErrorRPCInvalidParams,
-  [JSONRPCErrorCode.HandlerNotFound]: ErrorRPCHandlerFailed,
-  [JSONRPCErrorCode.RPCMissingResponse]: ErrorRPCMissingResponse,
-  [JSONRPCErrorCode.RPCOutputStreamError]: ErrorRPCOutputStreamError,
-  [JSONRPCErrorCode.RPCTimedOut]: ErrorRPCTimedOut,
-  [JSONRPCErrorCode.RPCStreamEnded]: ErrorRPCStreamEnded,
-  [JSONRPCErrorCode.RPCConnectionLocal]: ErrorRPCConnectionLocal,
-  [JSONRPCErrorCode.RPCConnectionPeer]: ErrorRPCConnectionPeer,
-  [JSONRPCErrorCode.RPCConnectionKeepAliveTimeOut]:
-    ErrorRPCConnectionKeepAliveTimeOut,
-  [JSONRPCErrorCode.RPCConnectionInternal]: ErrorRPCConnectionInternal,
-  [JSONRPCErrorCode.MissingHeader]: ErrorMissingHeader,
-  [JSONRPCErrorCode.HandlerAborted]: ErrorRPCHandlerFailed,
-  [JSONRPCErrorCode.MissingCaller]: ErrorMissingCaller,
 };
 
 /**
@@ -484,10 +420,10 @@ function clientOutputTransformStream<O extends JSONValue>(
       timer?.refresh();
       // `error` indicates it's an error message
       if ('error' in chunk) {
-        if (chunk.error.code === JSONRPCErrorCode.RPCRemote) {
+        if (chunk.error.code === errors.JSONRPCErrorCode.RPCRemote) {
           throw toError(JSON.parse(chunk.error.data as string), clientMetadata);
         }
-        const e = ErrorRPCProtocol.fromJSON(chunk.error);
+        const e = errors.ErrorRPCProtocol.fromJSON(chunk.error);
         Object.assign(e.data, clientMetadata);
         throw e;
       }
@@ -551,12 +487,12 @@ function parseHeadStream<T extends JSONRPCMessage>(
             bytesWritten += chunk.byteLength;
             parser.write(chunk);
           } catch (e) {
-            throw new rpcErrors.ErrorRPCParse(undefined, {
+            throw new errors.ErrorRPCParse(undefined, {
               cause: e,
             });
           }
           if (bytesWritten > bufferByteLimit) {
-            throw new rpcErrors.ErrorRPCMessageLength();
+            throw new errors.ErrorRPCMessageLength();
           }
         } else {
           // Wait for parser to end
@@ -575,7 +511,7 @@ function parseHeadStream<T extends JSONRPCMessage>(
 }
 
 function never(): never {
-  throw new ErrorRPC('This function should never be called');
+  throw new errors.ErrorRPC('This function should never be called');
 }
 
 export {
@@ -594,8 +530,6 @@ export {
   getHandlerTypes,
   parseHeadStream,
   promise,
-  JSONRPCErrorCode,
-  rpcProtocolErrors,
   isObject,
   sleep,
   never,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,13 +16,10 @@ import type {
 import { TransformStream } from 'stream/web';
 import { JSONParser } from '@streamparser/json';
 import { AbstractError } from '@matrixai/errors';
-import { JsonableValue } from 'ts-jest';
 import {
   ErrorRPCRemote,
   ErrorRPC,
-  ErrorRPCMethodNotImplemented,
   ErrorRPCConnectionInternal,
-  JSONRPCErrorCode,
   ErrorRPCStopping,
   ErrorRPCMessageLength,
   ErrorRPCParse,
@@ -36,6 +33,8 @@ import {
   ErrorRPCConnectionKeepAliveTimeOut,
   ErrorMissingHeader,
   ErrorMissingCaller,
+  ErrorRPCProtocol,
+  ErrorRPCInvalidParams,
 } from './errors';
 import * as rpcErrors from './errors';
 
@@ -235,21 +234,50 @@ function parseJSONRPCMessage<T extends JSONValue>(
   );
 }
 /**
- * Serializes an ErrorRPC instance into a JSONValue object suitable for RPC.
- * @param {ErrorRPC<any>} error - The ErrorRPC instance to serialize.
- * @param {any} [id] - Optional id for the error object in the RPC response.
+ * Serializes an Error instance into a JSONValue object suitable for RPC.
+ * @param {Error} error - The Error instance to serialize.
  * @returns {JSONValue} The serialized ErrorRPC instance.
  */
 function fromError(
-  errorin: rpcErrors.ErrorRPCProtocol<any>,
-  id?: any,
+  error: any,
 ): JSONValue {
-  const error: { [key: string]: JSONValue } = {
-    errorCode: errorin.code,
-    message: errorin.message,
-    data: errorin.data,
-    type: errorin.constructor.name,
-  };
+  // TODO: Linked-List traversal must be done iteractively rather than recusively to prevent stack overflow.
+  switch (typeof error) {
+    case "symbol":
+    case "bigint":
+    case "function":
+      throw TypeError(`${error} cannot be serialized`);
+  }
+
+  if (error instanceof Error) {
+    const cause = fromError(error.cause);
+    const timestamp: string = ((error as any).timestamp ?? new Date()).toJSON();
+    if (error instanceof AbstractError) {
+      return error.toJSON();
+    }
+    else if (error instanceof AggregateError) {
+      // AggregateError has an `errors` property
+      return {
+        type: error.constructor.name,
+        errors: error.errors.map(fromError),
+        message: error.message,
+        stack: error.stack,
+        timestamp,
+        cause
+      };
+    }
+
+    // If it's some other type of error then only serialise the message and
+    // stack (and the type of the error)
+    return {
+      type: error.name,
+      message: error.message,
+      stack: error.stack,
+      timestamp,
+      cause,
+    };
+  }
+
   return error;
 }
 
@@ -257,7 +285,7 @@ function fromError(
  * Error constructors for non-Polykey rpcErrors
  * Allows these rpcErrors to be reconstructed from RPC metadata
  */
-const standardErrors = {
+const standardErrors: { [key: string]: typeof Error | typeof AggregateError | typeof AbstractError } = {
   Error,
   TypeError,
   SyntaxError,
@@ -267,59 +295,72 @@ const standardErrors = {
   URIError,
   AggregateError,
   AbstractError,
-  ErrorRPCRemote,
-  ErrorRPC,
 };
-/**
- * Creates a replacer function that omits a specific key during serialization.
- * @returns {Function} The replacer function.
- */
-const createReplacer = () => {
-  return (keyToRemove) => {
-    return (key, value) => {
-      if (key === keyToRemove) {
-        return undefined;
-      }
 
-      if (key !== 'code') {
-        if (value instanceof rpcErrors.ErrorRPCProtocol) {
-          return {
-            code: value.code,
-            message: value.message,
-            data: value.data,
-            type: value.constructor.name,
-          };
-        }
-
-        if (value instanceof AggregateError) {
-          return {
-            type: value.constructor.name,
-            data: {
-              errors: value.errors,
-              message: value.message,
-              stack: value.stack,
-            },
-          };
-        }
-      }
-
-      return value;
-    };
-  };
-};
 /**
  * The replacer function to customize the serialization process.
  */
-const filterSensitive = createReplacer();
+const filterSensitive = (keyToRemove) => {
+  return (key, value) => {
+    if (key === keyToRemove) {
+      return undefined;
+    }
 
-const ErrorCodeToErrorType: {
-  [code: number]: new (...args: any[]) => ErrorRPC<any>;
-} = {
+    if (key !== 'code') {
+      if (value instanceof rpcErrors.ErrorRPCProtocol) {
+        return {
+          code: value.code,
+          message: value.message,
+          data: value.data,
+          type: value.constructor.name,
+        };
+      }
+
+      if (value instanceof AggregateError) {
+        return {
+          type: value.constructor.name,
+          data: {
+            errors: value.errors,
+            message: value.message,
+            stack: value.stack,
+          },
+        };
+      }
+    }
+
+    return value;
+  };
+};
+
+const enum JSONRPCErrorCode {
+  ParseError = -32700,
+  InvalidRequest = -32600,
+  MethodNotFound = -32601,
+  InvalidParams = -32602,
+  InternalError = -32603,
+  HandlerNotFound = -32000,
+  RPCStopping = -32001,
+  RPCMessageLength = -32003,
+  RPCMissingResponse = -32004,
+  RPCOutputStreamError = -32005,
+  RPCRemote = -32006,
+  RPCStreamEnded = -32007,
+  RPCTimedOut = -32008,
+  RPCConnectionLocal = -32010,
+  RPCConnectionPeer = -32011,
+  RPCConnectionKeepAliveTimeOut = -32012,
+  RPCConnectionInternal = -32013,
+  MissingHeader = -32014,
+  HandlerAborted = -32015,
+  MissingCaller = -32016,
+}
+
+const rpcProtocolErrors = {
   [JSONRPCErrorCode.RPCRemote]: ErrorRPCRemote,
   [JSONRPCErrorCode.RPCStopping]: ErrorRPCStopping,
   [JSONRPCErrorCode.RPCMessageLength]: ErrorRPCMessageLength,
   [JSONRPCErrorCode.ParseError]: ErrorRPCParse,
-  [JSONRPCErrorCode.InvalidParams]: ErrorRPC,
+  [JSONRPCErrorCode.InvalidParams]: ErrorRPCInvalidParams,
   [JSONRPCErrorCode.HandlerNotFound]: ErrorRPCHandlerFailed,
   [JSONRPCErrorCode.RPCMissingResponse]: ErrorRPCMissingResponse,
   [JSONRPCErrorCode.RPCOutputStreamError]: ErrorRPCOutputStreamError,
@@ -334,57 +375,70 @@ const ErrorCodeToErrorType: {
   [JSONRPCErrorCode.HandlerAborted]: ErrorRPCHandlerFailed,
   [JSONRPCErrorCode.MissingCaller]: ErrorMissingCaller,
 };
+
 /**
  * Deserializes an error response object into an ErrorRPCRemote instance.
  * @param {any} errorResponse - The error response object.
- * @param {any} [metadata] - Optional metadata for the deserialized error.
  * @returns {ErrorRPCRemote<any>} The deserialized ErrorRPCRemote instance.
  * @throws {TypeError} If the errorResponse object is invalid.
  */
 
-function toError(errorData: any, clientMetadata?: any): ErrorRPC<any> {
-  // Parsing if it's a string
-  if (typeof errorData === 'string') {
+function toError(errorData: JSONValue, metadata: JSONValue): any {
+  // If the value is an error then reconstruct it
+  if (
+    errorData != null &&
+    typeof errorData === 'object' &&
+    'type' in errorData &&
+    typeof errorData.type === 'string'
+  ) {
     try {
-      errorData = JSON.parse(errorData);
+      let eClass = standardErrors[errorData.type];
+      if (eClass != null) {
+        let e: Error;
+        switch (eClass) {
+          case AbstractError:
+            e = eClass.fromJSON(errorData);
+            break;
+          case AggregateError:
+            if (
+              !Array.isArray(errorData.errors) ||
+              typeof errorData.message !== 'string' ||
+              ('stack' in errorData && typeof errorData.stack !== 'string')
+            ) {
+              throw new TypeError(`cannot decode JSON to ${errorData.type}`);
+            }
+            e = new eClass(errorData.errors.map(toError), errorData.message);
+            e.stack = errorData.stack as string;
+            break;
+          default:
+            if (
+              typeof errorData.message !== 'string' ||
+              ('stack' in errorData && typeof errorData.stack !== 'string')
+            ) {
+              throw new TypeError(`Cannot decode JSON to ${errorData.type}`);
+            }
+            e = new (eClass as typeof Error)(errorData.message);
+            e.stack = errorData.stack as string;
+            break;
+        }
+        if ((e as any).data == null) {
+          (e as any).data = {};
+        }
+        Object.assign((e as any).data, metadata);
+        Object.assign((e as any).data, errorData);
+        return e;
+      }
     } catch (e) {
-      throw new ErrorRPCConnectionInternal('Unable to parse string to JSON');
+      // If `TypeError` which represents decoding failure
+      // then return value as-is
+      // Any other exception is a bug
+      if (!(e instanceof TypeError)) {
+        throw e;
+      }
     }
   }
-
-  // Check if errorData is an object and not null
-  if (typeof errorData !== 'object' || errorData === null) {
-    throw new ErrorRPCConnectionInternal(
-      'errorData should be a non-null object',
-    );
-  }
-
-  // Define default error values, you can modify this as per your needs
-  let errorCode = -32006;
-  let message = 'Unknown error';
-  let data = {};
-
-  // Check for errorCode and update if exists
-  if ('errorCode' in errorData) {
-    errorCode = errorData.errorCode;
-  }
-
-  if ('message' in errorData) {
-    message = errorData.message;
-  }
-
-  if ('data' in errorData) {
-    data = errorData.data;
-  }
-
-  // Map errorCode to a specific Error type
-  const ErrorType = ErrorCodeToErrorType[errorCode];
-  if (!ErrorType) {
-    throw new ErrorRPC('Unknown Error Code'); // Handle unknown error codes
-  }
-
-  const error = new ErrorType(message, { data, metadata: clientMetadata });
-  return error;
+  // Other values are returned as-is
+  return errorData;
 }
 
 /**
@@ -422,7 +476,7 @@ function clientInputTransformStream<I extends JSONValue>(
  * @param timer - Timer that gets refreshed each time a message is provided.
  */
 function clientOutputTransformStream<O extends JSONValue>(
-  clientMetadata?: JSONValue,
+  clientMetadata: JSONValue,
   timer?: Timer,
 ): TransformStream<JSONRPCResponse<O>, O> {
   return new TransformStream<JSONRPCResponse<O>, O>({
@@ -430,7 +484,12 @@ function clientOutputTransformStream<O extends JSONValue>(
       timer?.refresh();
       // `error` indicates it's an error message
       if ('error' in chunk) {
-        throw toError(chunk.error, clientMetadata);
+        if (chunk.error.code === JSONRPCErrorCode.RPCRemote) {
+          throw toError(JSON.parse(chunk.error.data as string), clientMetadata);
+        }
+        const e = ErrorRPCProtocol.fromJSON(chunk.error);
+        Object.assign(e.data, clientMetadata);
+        throw e;
       }
       controller.enqueue(chunk.result);
     },
@@ -535,6 +594,8 @@ export {
   getHandlerTypes,
   parseHeadStream,
   promise,
+  JSONRPCErrorCode,
+  rpcProtocolErrors,
   isObject,
   sleep,
   never,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -180,9 +180,7 @@ function parseJSONRPCResponse<T extends JSONValue>(
   } catch (e) {
     // Do nothing
   }
-  throw new errors.ErrorRPCParse(
-    'structure did not match a `JSONRPCResponse`',
-  );
+  throw new errors.ErrorRPCParse('structure did not match a `JSONRPCResponse`');
 }
 
 function parseJSONRPCMessage<T extends JSONValue>(
@@ -218,14 +216,12 @@ function parseJSONRPCMessage<T extends JSONValue>(
  * @param {Error} error - The Error instance to serialize.
  * @returns {JSONValue} The serialized ErrorRPC instance.
  */
-function fromError(
-  error: any,
-): JSONValue {
+function fromError(error: any): JSONValue {
   // TODO: Linked-List traversal must be done iteractively rather than recusively to prevent stack overflow.
   switch (typeof error) {
-    case "symbol":
-    case "bigint":
-    case "function":
+    case 'symbol':
+    case 'bigint':
+    case 'function':
       throw TypeError(`${error} cannot be serialized`);
   }
 
@@ -234,8 +230,7 @@ function fromError(
     const timestamp: string = ((error as any).timestamp ?? new Date()).toJSON();
     if (error instanceof AbstractError) {
       return error.toJSON();
-    }
-    else if (error instanceof AggregateError) {
+    } else if (error instanceof AggregateError) {
       // AggregateError has an `errors` property
       return {
         type: error.constructor.name,
@@ -244,8 +239,8 @@ function fromError(
           errors: error.errors.map(fromError),
           stack: error.stack,
           timestamp,
-          cause
-        }
+          cause,
+        },
       };
     }
 
@@ -258,7 +253,7 @@ function fromError(
         stack: error.stack,
         timestamp,
         cause,
-      }
+      },
     };
   }
 
@@ -269,7 +264,9 @@ function fromError(
  * Error constructors for non-Polykey rpcErrors
  * Allows these rpcErrors to be reconstructed from RPC metadata
  */
-const standardErrors: { [key: string]: typeof Error | typeof AggregateError | typeof AbstractError } = {
+const standardErrors: {
+  [key: string]: typeof Error | typeof AggregateError | typeof AbstractError;
+} = {
   Error,
   TypeError,
   SyntaxError,
@@ -334,7 +331,7 @@ function toError(errorData: JSONValue): any {
     typeof errorData.data === 'object'
   ) {
     try {
-      let eClass = standardErrors[errorData.type];
+      const eClass = standardErrors[errorData.type];
       if (eClass != null) {
         let e: Error;
         switch (eClass) {
@@ -352,7 +349,10 @@ function toError(errorData: JSONValue): any {
             ) {
               throw new TypeError(`cannot decode JSON to ${errorData.type}`);
             }
-            e = new eClass(errorData.data.errors.map(toError), errorData.message);
+            e = new eClass(
+              errorData.data.errors.map(toError),
+              errorData.message,
+            );
             e.stack = errorData.data.stack;
             break;
           default:
@@ -429,11 +429,12 @@ function clientOutputTransformStream<O extends JSONValue>(
       timer?.refresh();
       // `error` indicates it's an error message
       if ('error' in chunk) {
-        const e: errors.ErrorRPCProtocol<any> = errors.ErrorRPCProtocol.fromJSON(chunk.error);
+        const e: errors.ErrorRPCProtocol<any> =
+          errors.ErrorRPCProtocol.fromJSON(chunk.error);
         if (
           e instanceof errors.ErrorRPCRemote &&
           chunk.error.data != null &&
-          typeof chunk.error.data === "object" &&
+          typeof chunk.error.data === 'object' &&
           'cause' in chunk.error.data
         ) {
           e.metadata = clientMetadata;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -316,50 +316,6 @@ const filterSensitive = (keyToRemove) => {
   };
 };
 
-const enum JSONRPCErrorCode {
-  ParseError = -32700,
-  InvalidRequest = -32600,
-  MethodNotFound = -32601,
-  InvalidParams = -32602,
-  InternalError = -32603,
-  HandlerNotFound = -32000,
-  RPCStopping = -32001,
-  RPCMessageLength = -32003,
-  RPCMissingResponse = -32004,
-  RPCOutputStreamError = -32005,
-  RPCRemote = -32006,
-  RPCStreamEnded = -32007,
-  RPCTimedOut = -32008,
-  RPCConnectionLocal = -32010,
-  RPCConnectionPeer = -32011,
-  RPCConnectionKeepAliveTimeOut = -32012,
-  RPCConnectionInternal = -32013,
-  MissingHeader = -32014,
-  HandlerAborted = -32015,
-  MissingCaller = -32016,
-}
-
-const rpcProtocolErrors = {
-  [JSONRPCErrorCode.RPCRemote]: errors.ErrorRPCRemote,
-  [JSONRPCErrorCode.RPCStopping]: errors.ErrorRPCStopping,
-  [JSONRPCErrorCode.RPCMessageLength]: errors.ErrorRPCMessageLength,
-  [JSONRPCErrorCode.ParseError]: errors.ErrorRPCParse,
-  [JSONRPCErrorCode.InvalidParams]: errors.ErrorRPCInvalidParams,
-  [JSONRPCErrorCode.HandlerNotFound]: errors.ErrorRPCHandlerFailed,
-  [JSONRPCErrorCode.RPCMissingResponse]: errors.ErrorRPCMissingResponse,
-  [JSONRPCErrorCode.RPCOutputStreamError]: errors.ErrorRPCOutputStreamError,
-  [JSONRPCErrorCode.RPCTimedOut]: errors.ErrorRPCTimedOut,
-  [JSONRPCErrorCode.RPCStreamEnded]: errors.ErrorRPCStreamEnded,
-  [JSONRPCErrorCode.RPCConnectionLocal]: errors.ErrorRPCConnectionLocal,
-  [JSONRPCErrorCode.RPCConnectionPeer]: errors.ErrorRPCConnectionPeer,
-  [JSONRPCErrorCode.RPCConnectionKeepAliveTimeOut]:
-    errors.ErrorRPCConnectionKeepAliveTimeOut,
-  [JSONRPCErrorCode.RPCConnectionInternal]: errors.ErrorRPCConnectionInternal,
-  [JSONRPCErrorCode.MissingHeader]: errors.ErrorMissingHeader,
-  [JSONRPCErrorCode.HandlerAborted]: errors.ErrorRPCHandlerFailed,
-  [JSONRPCErrorCode.MissingCaller]: errors.ErrorMissingCaller,
-};
-
 /**
  * Deserializes an error response object into an ErrorRPCRemote instance.
  * @param {any} errorResponse - The error response object.
@@ -588,8 +544,6 @@ export {
   getHandlerTypes,
   parseHeadStream,
   promise,
-  JSONRPCErrorCode,
-  rpcProtocolErrors,
   isObject,
   sleep,
   never,

--- a/tests/RPC.test.ts
+++ b/tests/RPC.test.ts
@@ -187,7 +187,7 @@ describe('RPC', () => {
       rpcClient.methods.testMethod({
         hello: 'world',
       }),
-    ).rejects.toThrow(rpcErrors.ErrorRPCRemote);
+    ).rejects.toHaveProperty('message', 'some error');
 
     await rpcServer.stop({ force: true });
   });
@@ -466,70 +466,16 @@ describe('RPC', () => {
       // The promise should be rejected
       const rejection = await callProm;
 
+      // console.log(rejection)
+
       // The error should have specific properties
-      expect(rejection).toBeInstanceOf(rpcErrors.ErrorRPCRemote);
-      expect(rejection).toMatchObject({ code: -32006 });
+      expect(rejection).toBeInstanceOf(error.constructor);
+      expect(rejection).toMatchObject(error);
 
       // Cleanup
       await rpcServer.stop({ force: true });
     },
   );
-
-  testProp(
-    'RPC handles and sends sensitive errors',
-    [
-      rpcTestUtils.safeJsonValueArb,
-      rpcTestUtils.errorArb(rpcTestUtils.errorArb()),
-    ],
-    async (value, error) => {
-      const { clientPair, serverPair } = rpcTestUtils.createTapPairs<
-        Uint8Array,
-        Uint8Array
-      >();
-
-      class TestMethod extends UnaryHandler {
-        public handle = async (
-          _input: JSONValue,
-          _cancel: (reason?: any) => void,
-          _meta: Record<string, JSONValue> | undefined,
-          _ctx: ContextTimed,
-        ): Promise<JSONValue> => {
-          throw error;
-        };
-      }
-
-      const rpcServer = new RPCServer({
-        logger,
-        idGen,
-      });
-      await rpcServer.start({
-        manifest: {
-          testMethod: new TestMethod({}),
-        },
-      });
-      rpcServer.handleStream({ ...serverPair, cancel: () => {} });
-
-      const rpcClient = new RPCClient({
-        manifest: {
-          testMethod: new UnaryCaller(),
-        },
-        streamFactory: async () => {
-          return { ...clientPair, cancel: () => {} };
-        },
-        logger,
-        idGen,
-      });
-
-      const callProm = rpcClient.methods.testMethod(ErrorRPCRemote.description);
-
-      // Use Jest's `.rejects` to handle the promise rejection
-      await expect(callProm).rejects.toBeInstanceOf(rpcErrors.ErrorRPCRemote);
-      await expect(callProm).rejects.not.toHaveProperty('cause.stack');
-
-      await rpcServer.stop({ force: true });
-    },
-  );
-
   test('middleware can end stream early', async () => {
     const { clientPair, serverPair } = rpcTestUtils.createTapPairs<
       Uint8Array,
@@ -928,12 +874,11 @@ describe('RPC', () => {
   );
 
   testProp(
-    'RPC Serializes and Deserializes ErrorRPCRemote',
+    'RPC Serializes and Deserializes Error',
     [
-      rpcTestUtils.safeJsonValueArb,
       rpcTestUtils.errorArb(rpcTestUtils.errorArb()),
     ],
-    async (value, error) => {
+    async (error) => {
       const { clientPair, serverPair } = rpcTestUtils.createTapPairs<
         Uint8Array,
         Uint8Array
@@ -971,34 +916,18 @@ describe('RPC', () => {
         idGen,
       });
 
-      const errorInstance = new ErrorRPCRemote({
-        metadata: -123123,
-        message: 'parse error',
-        options: { cause: 'Random cause' },
-      });
-
-      const serializedError = fromError(errorInstance);
-      const callProm = rpcClient.methods.testMethod(serializedError);
-      await expect(callProm).rejects.toThrow(rpcErrors.ErrorRPCRemote);
-
-      const deserializedError = toError(serializedError);
-
-      expect(deserializedError).toBeInstanceOf(ErrorRPCRemote);
-
-      // Check properties explicitly
-      const { code, message, data } = deserializedError as ErrorRPCRemote<any>;
-      expect(code).toBe(-32006);
+      const callProm = rpcClient.methods.testMethod({});
+      const callError = await callProm.catch((e) => e);
 
       await rpcServer.stop({ force: true });
     },
   );
   testProp(
-    'RPC Serializes and Deserializes ErrorRPCRemote with Custom Replacer Function',
+    'RPC Serializes and Deserializes Error with Custom Replacer Function',
     [
-      rpcTestUtils.safeJsonValueArb,
       rpcTestUtils.errorArb(rpcTestUtils.errorArb()),
     ],
-    async (value, error) => {
+    async (error) => {
       const { clientPair, serverPair } = rpcTestUtils.createTapPairs<
         Uint8Array,
         Uint8Array
@@ -1017,6 +946,7 @@ describe('RPC', () => {
       const rpcServer = new RPCServer({
         logger,
         idGen,
+        replacer: filterSensitive('stack'),
       });
       await rpcServer.start({
         manifest: {
@@ -1036,30 +966,8 @@ describe('RPC', () => {
         idGen,
       });
 
-      const errorInstance = new ErrorRPCRemote({
-        metadata: -32006,
-        message: '',
-        options: {
-          cause: error,
-          data: 'asda',
-        },
-      });
-
-      const serializedError = JSON.parse(
-        JSON.stringify(fromError(errorInstance), filterSensitive('data')),
-      );
-
-      const callProm = rpcClient.methods.testMethod(serializedError);
-      const catchError = await callProm.catch((e) => e);
-
-      const deserializedError = toError(serializedError);
-
-      expect(deserializedError).toBeInstanceOf(ErrorRPCRemote);
-
-      // Check properties explicitly
-      const { code, message, data } = deserializedError as ErrorRPCRemote<any>;
-      expect(code).toBe(-32006);
-      expect(data).toBe(undefined);
+      const callProm = rpcClient.methods.testMethod({});
+      const callError = await callProm.catch((e) => e);
 
       await rpcServer.stop({ force: true });
     },
@@ -1070,7 +978,9 @@ describe('RPC', () => {
       Uint8Array
     >();
 
-    const testReason = Error('test error');
+    const errorMessage = 'test error';
+
+    const testReason = Error(errorMessage);
 
     class TestMethod extends UnaryHandler {
       public handle = async (
@@ -1115,6 +1025,6 @@ describe('RPC', () => {
 
     await rpcServer.stop({ force: true, reason: testReason });
 
-    await expect(testProm).toReject();
+    await expect(testProm).rejects.toHaveProperty('message', errorMessage);
   });
 });

--- a/tests/RPC.test.ts
+++ b/tests/RPC.test.ts
@@ -873,9 +873,7 @@ describe('RPC', () => {
 
   testProp(
     'RPC Serializes and Deserializes Error',
-    [
-      rpcTestUtils.errorArb(rpcTestUtils.errorArb()),
-    ],
+    [rpcTestUtils.errorArb(rpcTestUtils.errorArb())],
     async (error) => {
       const { clientPair, serverPair } = rpcTestUtils.createTapPairs<
         Uint8Array,
@@ -924,9 +922,7 @@ describe('RPC', () => {
   );
   testProp(
     'RPC Serializes and Deserializes Error with Custom Replacer Function',
-    [
-      rpcTestUtils.errorArb(rpcTestUtils.errorArb()),
-    ],
+    [rpcTestUtils.errorArb(rpcTestUtils.errorArb())],
     async (error) => {
       const { clientPair, serverPair } = rpcTestUtils.createTapPairs<
         Uint8Array,
@@ -1026,7 +1022,7 @@ describe('RPC', () => {
     const testProm = rpcClient.methods.testMethod({});
 
     await rpcServer.stop({ force: true, reason: testReason });
-    const rejection = await testProm.catch(e => e);
+    const rejection = await testProm.catch((e) => e);
     expect(rejection).toBeInstanceOf(ErrorRPCRemote);
     expect(rejection.cause).toBeInstanceOf(Error);
     expect(rejection.cause.message).toBe(errorMessage);

--- a/tests/RPC.test.ts
+++ b/tests/RPC.test.ts
@@ -466,11 +466,9 @@ describe('RPC', () => {
       // The promise should be rejected
       const rejection = await callProm;
 
-      // console.log(rejection)
-
       // The error should have specific properties
       expect(rejection).toBeInstanceOf(error.constructor);
-      expect(rejection).toMatchObject(error);
+      expect(rejection).toEqual(error);
 
       // Cleanup
       await rpcServer.stop({ force: true });
@@ -919,6 +917,8 @@ describe('RPC', () => {
       const callProm = rpcClient.methods.testMethod({});
       const callError = await callProm.catch((e) => e);
 
+      expect(callError).toEqual(error);
+
       await rpcServer.stop({ force: true });
     },
   );
@@ -968,6 +968,8 @@ describe('RPC', () => {
 
       const callProm = rpcClient.methods.testMethod({});
       const callError = await callProm.catch((e) => e);
+
+      expect(callError).toEqual(error);
 
       await rpcServer.stop({ force: true });
     },
@@ -1024,7 +1026,9 @@ describe('RPC', () => {
     const testProm = rpcClient.methods.testMethod({});
 
     await rpcServer.stop({ force: true, reason: testReason });
-
-    await expect(testProm).rejects.toHaveProperty('message', errorMessage);
+    const rejection = await testProm.catch(e => e);
+    expect(rejection).toBeInstanceOf(ErrorRPCRemote);
+    expect(rejection.cause).toBeInstanceOf(Error);
+    expect(rejection.cause.message).toBe(errorMessage);
   });
 });

--- a/tests/RPCClient.test.ts
+++ b/tests/RPCClient.test.ts
@@ -295,7 +295,7 @@ describe(`${RPCClient.name}`, () => {
     'generic duplex caller can throw received error message with sensitive',
     [
       fc.array(rpcTestUtils.jsonRpcResponseResultArb()),
-      rpcTestUtils.jsonRpcResponseErrorArb(rpcTestUtils.errorArb(), true),
+      rpcTestUtils.jsonRpcResponseErrorArb(rpcTestUtils.errorArb()),
     ],
     async (messages, errorMessage) => {
       const inputStream = rpcTestUtils.messagesToReadableStream([
@@ -336,7 +336,6 @@ describe(`${RPCClient.name}`, () => {
       fc.array(rpcTestUtils.jsonRpcResponseResultArb()),
       rpcTestUtils.jsonRpcResponseErrorArb(
         rpcTestUtils.errorArb(rpcTestUtils.errorArb()),
-        true,
       ),
     ],
     async (messages, errorMessage) => {

--- a/tests/RPCServer.test.ts
+++ b/tests/RPCServer.test.ts
@@ -465,7 +465,7 @@ describe(`${RPCServer.name}`, () => {
       rpcServer.handleStream(readWriteStream);
       const rawErrorMessage = (await outputResult)[0]!.toString();
       const errorMessage = JSON.parse(rawErrorMessage);
-      expect(errorMessage.error.message).toEqual(error.description);
+      expect(errorMessage.error.message).toEqual(error.message);
       reject();
       await expect(errorProm).toReject();
       await rpcServer.stop({ force: true });
@@ -508,7 +508,7 @@ describe(`${RPCServer.name}`, () => {
       rpcServer.handleStream(readWriteStream);
       const rawErrorMessage = (await outputResult)[0]!.toString();
       const errorMessage = JSON.parse(rawErrorMessage);
-      expect(errorMessage.error.message).toEqual(error.description);
+      expect(errorMessage.error.message).toEqual(error.message);
       reject();
       await expect(errorProm).toReject();
       await rpcServer.stop({ force: true });
@@ -557,7 +557,7 @@ describe(`${RPCServer.name}`, () => {
         await writer.write(Buffer.from(JSON.stringify(message)));
       }
       // Abort stream
-      const writerReason = Symbol('writerAbort');
+      const writerReason = new Error('writerAbort');
       await writer.abort(writerReason);
       // We should get an error RPC message
       await expect(outputResult).toResolve();

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -23,12 +23,4 @@ describe('utils tests', () => {
     },
     { numRuns: 1000 },
   );
-  test('fromError', () => {
-    expect(rpcUtils.fromError(undefined)).toBe(undefined);
-    expect(rpcUtils.fromError(null)).toBe(null);
-    expect(rpcUtils.fromError("123")).toBe("123");
-    expect(rpcUtils.fromError(123)).toBe(123);
-    expect(rpcUtils.fromError(new Error("message"))).toHaveProperty("message", "message");
-    expect(rpcUtils.fromError(new Error("message", { cause: new Error() }))).toHaveProperty(["cause", "type"], "Error");
-  });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -23,4 +23,12 @@ describe('utils tests', () => {
     },
     { numRuns: 1000 },
   );
+  test('fromError', () => {
+    expect(rpcUtils.fromError(undefined)).toBe(undefined);
+    expect(rpcUtils.fromError(null)).toBe(null);
+    expect(rpcUtils.fromError("123")).toBe("123");
+    expect(rpcUtils.fromError(123)).toBe(123);
+    expect(rpcUtils.fromError(new Error("message"))).toHaveProperty("message", "message");
+    expect(rpcUtils.fromError(new Error("message", { cause: new Error() }))).toHaveProperty(["cause", "type"], "Error");
+  });
 });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -151,10 +151,12 @@ const jsonRpcErrorArb = (
       {
         code: fc.integer(),
         message: fc.string(),
-        data: error.map((e) => JSON.stringify(fromError(e))),
+        data: fc.record({
+          cause: error.map((e) => JSON.stringify(fromError(e)))
+        }),
       },
       {
-        requiredKeys: ['code', 'message'],
+        requiredKeys: ['code', 'message', 'data'],
       },
     )
     .noShrink() as fc.Arbitrary<JSONRPCError>;

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -16,6 +16,7 @@ import * as utils from '@/utils';
 import { fromError } from '@/utils';
 import * as rpcErrors from '@/errors';
 import { ErrorRPC } from '@/errors';
+import { AbstractError } from '@matrixai/errors';
 
 /**
  * This is used to convert regular chunks into randomly sized chunks based on
@@ -260,21 +261,17 @@ const errorArb = (
 ) =>
   cause.chain((cause) =>
     fc.oneof(
-      fc.constant(new rpcErrors.ErrorRPCRemote()),
       fc.constant(new rpcErrors.ErrorRPCMessageLength(undefined)),
       fc.constant(
-        new rpcErrors.ErrorRPCRemote(
-          {
+        new AbstractError("message", {
+          cause,
+          data: {
             command: 'someCommand',
             host: `someHost`,
             port: 0,
-          },
-          undefined,
-          {
-            cause,
-          },
-        ),
-      ),
+          }
+        })
+      )
     ),
   );
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -149,7 +149,7 @@ const jsonRpcErrorArb = (
   fc
     .record(
       {
-        code: fc.integer(),
+        code: fc.constant(utils.JSONRPCErrorCode.RPCRemote),
         message: fc.string(),
         data: fc.record({
           cause: error.map((e) => JSON.stringify(fromError(e)))

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -149,7 +149,7 @@ const jsonRpcErrorArb = (
   fc
     .record(
       {
-        code: fc.constant(utils.JSONRPCErrorCode.RPCRemote),
+        code: fc.constant(rpcErrors.JSONRPCErrorCode.RPCRemote),
         message: fc.string(),
         data: fc.record({
           cause: error.map((e) => JSON.stringify(fromError(e)))

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -12,11 +12,11 @@ import type {
 } from '@/types';
 import { ReadableStream, WritableStream, TransformStream } from 'stream/web';
 import { fc } from '@fast-check/jest';
+import { AbstractError } from '@matrixai/errors';
 import * as utils from '@/utils';
 import { fromError } from '@/utils';
 import * as rpcErrors from '@/errors';
 import { ErrorRPC } from '@/errors';
-import { AbstractError } from '@matrixai/errors';
 
 /**
  * This is used to convert regular chunks into randomly sized chunks based on
@@ -152,7 +152,7 @@ const jsonRpcErrorArb = (
         code: fc.constant(rpcErrors.JSONRPCErrorCode.RPCRemote),
         message: fc.string(),
         data: fc.record({
-          cause: error.map((e) => JSON.stringify(fromError(e)))
+          cause: error.map((e) => JSON.stringify(fromError(e))),
         }),
       },
       {
@@ -161,10 +161,7 @@ const jsonRpcErrorArb = (
     )
     .noShrink() as fc.Arbitrary<JSONRPCError>;
 
-const jsonRpcResponseErrorArb = (
-  error?: fc.Arbitrary<ErrorRPC<any>>,
-  sensitive: boolean = false,
-) =>
+const jsonRpcResponseErrorArb = (error?: fc.Arbitrary<ErrorRPC<any>>) =>
   fc
     .record({
       jsonrpc: fc.constant('2.0'),
@@ -265,15 +262,15 @@ const errorArb = (
     fc.oneof(
       fc.constant(new rpcErrors.ErrorRPCMessageLength(undefined)),
       fc.constant(
-        new AbstractError("message", {
+        new AbstractError('message', {
           cause,
           data: {
             command: 'someCommand',
             host: `someHost`,
             port: 0,
-          }
-        })
-      )
+          },
+        }),
+      ),
     ),
   );
 


### PR DESCRIPTION
### Description

#### FromError/ToError

```ts
function toError(errorData: JSONValue): any {}
function fromError(error: any): JSONValue {}
```

fromError will need to be any -> JSONValue
If it is an error or a serialisable value it must be serialised, otherwise throw a TypeError indicating that it cannot

toError will need to be JSONValue -> any
unknown values will be thrown upwards as is, as the peer is able to throw anything they want that is JSON serializable

if the JSONValue passed into toError is a serialized error, and the error.type cannot be found, it will be deserialised into a generic Error

When fromError throws a TypeError, this will be dispatched on the RPCServer instance, to notify the user that most likely one of their handlers is throwing an non-serialisable value. This is also wrapped in an ErrorRPCRemote and sent to the client so that they know that an internal server error has occured due to an attempt to throw.

#### Error Object

There have been some changes regarding how errors are mapped to JSON-RPC messages.

A typical JSON-RPC message containing an ErrorRPCRemote would look like the following:

```js
{
  jsonrpc: '2.0',
  error: { 
    code: -32006, // Maps to ErrorRPCRemote 
    message: '...', 
    data: {
      meta: { caller: '...' }, // <- DOES NOT EXIST ON TRANSPORT
      data: {

      },
      cause: {
        type: 'ErrorX...', // Maps to ErrorRPCRemote 
        message: '...', 
        data: {
          data: {

          },
          cause: {
            ... // recurse of parent structure
          },
          timestamp: new Date(),
          stack: "..."
        },
      },
      timestamp: new Date(),
      stack: "..."
    },
  }, 
  id: null
}
```

This means that all user-thrown application-level errors are now mapped to a type on an ErrorRPCRemote error object, rather than to an error object directly like before. This change was possibly due to a misunderstanding when toError/fromError was initially being speced out. But please correct this if that is not the case.

As of current, the only protocol-level errors that get transmitted between peers are ErrorRPCRemote, which is a wrapper for an application level error, with all other errors only being thrown on the client. However, the aforementioned change may help if we ever decide to introduce protocol-level errors that are transmitted. 

Also, the error object.message now carries the error.message rather than the error.description. This has been done for the sake of convenience, it making more sense, and also the fact that the descriptions in all the Errors that extend ErrorRPCProtocol have a static description.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #10 

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Make ToError/FromError correctly serialize and deserialize error details.
- [x] 2. Amend ErrorObject data-structure

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
