### PR TITLE
Update handler and caller timeouts to be able to overwrite server and client default timeouts regardless of value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ class Sum extends ClientHandler<ContainerType, number, number> {
 async function startServer() {
   const rpcServer = new RPCServer({
     logger: new Logger('rpc-server'),
-    handlerTimeoutTime: 60000,
+    timeoutTime: 60000,
     idGen,
   });
 
@@ -421,7 +421,7 @@ function factorialOf(n: number): number {
 
 async function startServer() {
   const rpcServer = new RPCServer({
-    handlerTimeoutTime: 200,
+    timeoutTime: 200,
     logger,
     idGen,
   });
@@ -671,7 +671,7 @@ async function startServer() {
   const wss = new WebSocket.Server({ port: 8080 });
   const rpcServer = new RPCServer({
     logger: new Logger('rpc-server'),
-    handlerTimeoutTime: 1000,
+    timeoutTime: 1000,
     idGen,
   });
   rpcServer.start({
@@ -835,7 +835,7 @@ function createSyntheticStreams() {
 async function startServer() {
   const rpcServer = new RPCServer({
     logger: new Logger('rpc-server'),
-    handlerTimeoutTime: 1000,
+    timeoutTime: 1000,
     idGen,
   });
 

--- a/README.md
+++ b/README.md
@@ -924,6 +924,35 @@ class TestMethod extends UnaryHandler {
 }
 ```
 
+### Timeout Priority
+
+A `timeoutTime` can be passed both to the constructors of `RPCServer` and `RPCClient`. This is the default `timeoutTime` for all callers/handlers.
+
+In the case of `RPCServer`, a `timeout` can be specified when extending any `Handler` class. This will override the default `timeoutTime` set on `RPCServer` for that handler only.
+
+```ts
+class TestMethodArbitraryTimeout extends UnaryHandler {
+  public timeout = 100;
+  public handle = async (
+    input: JSONValue,
+    _cancel,
+    _meta,
+    ctx_,
+  ): Promise<JSONValue> => {
+    return input;
+  };
+}
+```
+
+In the case of `RPCClient`, a `ctx` with the property `timer` can be supplied with a `Timer` instance or `number` when making making an RPC call. This will override the default `timeoutTime` set on `RPCClient` for that call only.
+
+```ts
+await rpcClient.methods.testMethod({}, { timer: 100 });
+await rpcClient.methods.testMethod({}, { timer: new Timer(undefined, 100) });
+```
+
+It's important to note that any of these timeouts will ultimately be overridden by the shortest timeout of the server and client combined using the timeout middleware below.
+
 ### Timeout Middleware
 
 The `timeoutMiddleware` sets an RPCServer's timeout based on the lowest timeout between the Client and the Server. This is so that handlers can eagerly time out and stop processing as soon as it is known that the client has timed out.

--- a/src/RPCClient.ts
+++ b/src/RPCClient.ts
@@ -103,6 +103,9 @@ class RPCClient<M extends ClientManifest> {
     idGen?: IdGen;
     toError?: ToError;
   }) {
+    if (timeoutTime < 0) {
+      throw new errors.ErrorRPCInvalidTimeout();
+    }
     this.idGen = idGen;
     this.callerTypes = utils.getHandlerTypes(manifest);
     this.streamFactory = streamFactory;

--- a/src/RPCClient.ts
+++ b/src/RPCClient.ts
@@ -41,7 +41,7 @@ class RPCClient<M extends ClientManifest> {
     this.onTimeoutCallback = callback;
   }
   // Method proxies
-  public readonly streamKeepAliveTimeoutTime: number;
+  public readonly timeoutTime: number;
   public readonly methodsProxy = new Proxy(
     {},
     {
@@ -76,7 +76,7 @@ class RPCClient<M extends ClientManifest> {
    * The middlewareFactory needs to be a function that creates a pair of
    * transform streams that convert `JSONRPCRequest` to `Uint8Array` on the forward
    * path and `Uint8Array` to `JSONRPCResponse` on the reverse path.
-   * @param obj.streamKeepAliveTimeoutTime - Timeout time used if no timeout timer was provided when making a call.
+   * @param obj.timeoutTime - Timeout time used if no timeout timer was provided when making a call.
    * Defaults to 60,000 milliseconds.
    * for a client call.
    * @param obj.logger
@@ -85,7 +85,7 @@ class RPCClient<M extends ClientManifest> {
     manifest,
     streamFactory,
     middlewareFactory = middleware.defaultClientMiddlewareWrapper(),
-    streamKeepAliveTimeoutTime = Infinity,
+    timeoutTime = Infinity,
     logger,
     toError = utils.toError,
     idGen = () => null,
@@ -98,7 +98,7 @@ class RPCClient<M extends ClientManifest> {
       JSONRPCResponse,
       Uint8Array
     >;
-    streamKeepAliveTimeoutTime?: number;
+    timeoutTime?: number;
     logger?: Logger;
     idGen?: IdGen;
     toError?: ToError;
@@ -107,7 +107,7 @@ class RPCClient<M extends ClientManifest> {
     this.callerTypes = utils.getHandlerTypes(manifest);
     this.streamFactory = streamFactory;
     this.middlewareFactory = middlewareFactory;
-    this.streamKeepAliveTimeoutTime = streamKeepAliveTimeoutTime;
+    this.timeoutTime = timeoutTime;
     this.logger = logger ?? new Logger(this.constructor.name);
     this.toError = toError;
   }
@@ -254,7 +254,7 @@ class RPCClient<M extends ClientManifest> {
     let timer: Timer;
     if (!(ctx.timer instanceof Timer)) {
       timer = new Timer({
-        delay: ctx.timer ?? this.streamKeepAliveTimeoutTime,
+        delay: ctx.timer ?? this.timeoutTime,
       });
     } else {
       timer = ctx.timer;
@@ -403,7 +403,7 @@ class RPCClient<M extends ClientManifest> {
     let timer: Timer;
     if (!(ctx.timer instanceof Timer)) {
       timer = new Timer({
-        delay: ctx.timer ?? this.streamKeepAliveTimeoutTime,
+        delay: ctx.timer ?? this.timeoutTime,
       });
     } else {
       timer = ctx.timer;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -27,6 +27,14 @@ class ErrorRPCCallerFailed<T> extends ErrorRPC<T> {
   static description = 'Failed to call stream';
 }
 
+class ErrorRPCInvalidTimeout<T> extends ErrorRPC<T> {
+  static description = 'Invalid timeout provided';
+}
+
+class ErrorRPCInvalidHandlerTimeout<T> extends ErrorRPC<T> {
+  static description = 'Invalid handler timeout provided';
+}
+
 abstract class ErrorRPCProtocol<T> extends ErrorRPC<T> {
   static error = 'RPC Protocol Error';
   code: number;
@@ -257,6 +265,8 @@ export {
   ErrorRPCConnectionLocal,
   ErrorRPCConnectionPeer,
   ErrorRPCConnectionKeepAliveTimeOut,
+  ErrorRPCInvalidTimeout,
+  ErrorRPCInvalidHandlerTimeout,
   ErrorRPCConnectionInternal,
   ErrorMissingHeader,
   ErrorHandlerAborted,

--- a/tests/RPC.test.ts
+++ b/tests/RPC.test.ts
@@ -924,7 +924,7 @@ describe('RPC', () => {
     const rpcServer = new RPCServer({
       logger,
       idGen,
-      handlerTimeoutTime: 150,
+      timeoutTime: 150,
     });
     await rpcServer.start({
       manifest: {
@@ -984,7 +984,7 @@ describe('RPC', () => {
       const rpcServer = new RPCServer({
         logger,
         idGen,
-        handlerTimeoutTime: 150,
+        timeoutTime: 150,
       });
       await rpcServer.start({
         manifest: {

--- a/tests/RPC.test.ts
+++ b/tests/RPC.test.ts
@@ -609,7 +609,7 @@ describe('RPC', () => {
       const rpcServer = new RPCServer({
         logger,
         idGen,
-        handlerTimeoutTime: timeout,
+        timeoutTime: timeout,
       });
       await rpcServer.start({
         manifest: {
@@ -701,7 +701,7 @@ describe('RPC', () => {
       const rpcServer = new RPCServer({
         logger,
         idGen,
-        handlerTimeoutTime: 1,
+        timeoutTime: 1,
       });
       await rpcServer.start({ manifest: { testMethod: new TestMethod({}) } });
       // Register callback
@@ -774,8 +774,7 @@ describe('RPC', () => {
       const rpcServer = new RPCServer({
         logger,
         idGen,
-
-        handlerTimeoutTime: 400,
+        timeoutTime: 400,
       });
       await rpcServer.start({
         manifest: {
@@ -839,11 +838,10 @@ describe('RPC', () => {
           await abortProm.p;
         };
       }
-
       const rpcServer = new RPCServer({
         logger,
         idGen,
-        handlerTimeoutTime: Infinity,
+        timeoutTime: Infinity,
       });
       await rpcServer.start({ manifest: { testMethod: new TestMethod({}) } });
       rpcServer.handleStream({ ...serverPair, cancel: () => {} });

--- a/tests/RPCClient.test.ts
+++ b/tests/RPCClient.test.ts
@@ -1242,9 +1242,12 @@ describe(`${RPCClient.name}`, () => {
           timeoutTime: higherTimeoutTime,
         });
 
-        await rpcClient.duplexStreamCaller<JSONRPCParams, JSONRPCResult>(methodName, {
-          timer: lowerTimeoutTime,
-        });
+        await rpcClient.duplexStreamCaller<JSONRPCParams, JSONRPCResult>(
+          methodName,
+          {
+            timer: lowerTimeoutTime,
+          },
+        );
 
         const ctx = await ctxP;
         expect(ctx.timer.delay).toBe(lowerTimeoutTime);
@@ -1274,9 +1277,12 @@ describe(`${RPCClient.name}`, () => {
           timeoutTime: lowerTimeoutTime,
         });
 
-        await rpcClient.duplexStreamCaller<JSONRPCParams, JSONRPCResult>(methodName, {
-          timer: higherTimeoutTime,
-        });
+        await rpcClient.duplexStreamCaller<JSONRPCParams, JSONRPCResult>(
+          methodName,
+          {
+            timer: higherTimeoutTime,
+          },
+        );
 
         const ctx = await ctxP;
         expect(ctx.timer.delay).toBe(higherTimeoutTime);

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -274,6 +274,15 @@ const errorArb = (
     ),
   );
 
+const timeoutsArb = fc
+  .integer({ min: 0 })
+  .chain((lowerTimeoutTime) =>
+    fc.tuple(
+      fc.constant(lowerTimeoutTime),
+      fc.integer({ min: lowerTimeoutTime }),
+    ),
+  );
+
 export {
   binaryStreamToSnippedStream,
   binaryStreamToNoisyStream,
@@ -295,4 +304,5 @@ export {
   tapTransformStream,
   createTapPairs,
   errorArb,
+  timeoutsArb,
 };


### PR DESCRIPTION
### Description

Previously `Handler.timeout` could only overwrite the default timeout if it was lesser than the default timeout, this is problematic in instances where we need a greater timeout than default timeout as in 

https://github.com/MatrixAI/Polykey/pull/589#event-10717978415

The previous implementation of timeout was as so: 

```ts
if (handler == null) {
        await cleanUp(new errors.ErrorRPCHandlerFailed('Missing handler'));
        return;
      }
      if (abortController.signal.aborted) {
        await cleanUp(
          new errors.ErrorHandlerAborted('Aborted', {
            cause: new errors.ErrorHandlerAborted(),
          }),
        );
        return;
      }
      // Setting up Timeout logic
      const timeout = this.defaultTimeoutMap.get(method);
      if (timeout != null && timeout < this.handlerTimeoutTime) {
        // Reset timeout with new delay if it is less than the default
        timer.reset(timeout);
      } else {
        // Otherwise refresh
        timer.refresh();
}
```

This PR aims to override this by allowing `Handler.timeout` to have priority over normal timeout irrespective of value, this is implemented as so.

```ts
     const timeout = this.defaultTimeoutMap.get(method);
      if (timeout != null) {
        // Reset handlerTimeout with new delay if it is less than the default
        timer.reset(timeout);
      } else {
        // Otherwise refresh
        timer.refresh();
      }
```

With this we hope to be able to have custom timeout for handlers even if we need to extend the timeout to be more than the default value.

Further, this PR aims to write tests to test this functionality, these tests are simply structured to have a handler timeout, which can be either greater or lesser than the default server timeout, the `handlerTimeoutTime,` and then to check if the updated timeout is set as the `ctx` timer.

These tests can be structured as so: 

```ts
class TestMethodLongTimeout extends UnaryHandler {
        // This will override the default timeout from 50 to 250, thereby increasing it.
        timeout = 250;
        public handle = async (
          input: JSONValue,
          _cancel,
          _meta,
          ctx_,
        ): Promise<JSONValue> => {
          ctxLongProm.resolveP(ctx_);
          await waitProm.p;
          return input;
        };
      }
      const rpcServer = new RPCServer({
        handlerTimeoutTime: 50,
CMCDragonkai marked this conversation as resolved.
        logger,
        idGen,
      });
      await rpcServer.start({
        manifest: {
          testLong: new TestMethodLongTimeout({}),
        },
      });
```

In the aforementioned test, the server timeout was set to 50, and the Handler timeout to 250, consequently the final ctx timer should be 250, and this is expected. 

Similar test for a lesser timeout is conducted.

Although the functionality of setting Client timeout through caller was already present, the tests to check the same were lacking, this PR also aims to include such tests. These tests would be structured similarly to the server tests wherein a client is created with a `streamKeepAliveTimeoutTime` and then the caller sets a different timeout, either greater or lesser, and we expect the ctx timer to be set according to the caller set timer, which can be expected as such: 

```ts
        const rpcClient = new RPCClient({
          manifest: {},
          streamFactory: async (ctx) => {
            ctxProm.resolveP(ctx);
            return streamPair;
          },
          logger,
          idGen,
          // Setting timeout here to 150ms
          streamKeepAliveTimeoutTime: 150,
        });

        const callerInterface = await rpcClient.duplexStreamCaller<
          JSONValue,
          JSONValue
        >(methodName, { timer: 100 });

        const ctx = await ctxProm.p;
        expect(ctx.timer.delay).toEqual(100);
```

In the aforementioned test, the client timeout is initially set to 150ms, and then changed to 100ms, we expect the timer delay to be 100.

### Issues Fixed

* Related https://github.com/MatrixAI/Polykey/issues/588

### Tasks

- [x] 1. Change implementation from overriding when timeout is only lesser to always
- [x] 2. Fix jests
- [x] 3. Add new jests

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
