### PR TITLE
Timeouts are Now Cancelled After The Initial Server-Sent Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,14 @@ If the client were to time out, the stream is forcibly closed and `ErrorRPCTimed
 
 If the server were to time out, is is advisory. Meaning that the server may choose to optionally eagerly throw `ErrorRPCTimedOut`, or continue processing as normal.
 
+After the client receives the subsequent message from the server, the timeout timer is cancelled.
+
+Likewise on the server, the timeout timer is cancelled after the first message is sent to the client.
+
+This means that the timeout for Streaming calls acts as a Proof of Life, and after it is established, the timeout no longer applies. This allows for long-running Streaming calls.
+
+Note that when supplying a `Timer` instance to the call-site in `RPCClient`, the timeout timer will not be cancelled. As it is expected for the library to not mutate the passed-in `Timer`, and for the user to expect that receiving a messsage will have meaned that the timer no longer matters.
+
 #### Throwing Timeouts Server-Side
 
 By default, a timeout will not cause an RPC call to automatically throw, this must be manually done by the handler when it receives the abort signal from `ctx.signal`. An example of this is like so:

--- a/src/RPCClient.ts
+++ b/src/RPCClient.ts
@@ -307,10 +307,11 @@ class RPCClient<M extends ClientManifest> {
       },
       () => {}, // Ignore cancellation error
     );
-    // Deciding if we want to allow refreshing
-    // We want to refresh timer if none was provided
-    const refreshingTimer: Timer | undefined =
-      ctx.timer == null ? timer : undefined;
+    // Deciding if we want to allow cancelling
+    // We want to cancel timer if none was provided
+    const cancellingTimer: Timer | undefined = !(ctx.timer instanceof Timer)
+      ? timer
+      : undefined;
     // Composing stream transforms and middleware
     const metadata = {
       ...(rpcStream.meta ?? {}),
@@ -319,12 +320,10 @@ class RPCClient<M extends ClientManifest> {
     const outputMessageTransformStream = utils.clientOutputTransformStream<O>(
       metadata,
       this.toError,
-      refreshingTimer,
+      cancellingTimer,
     );
-    const inputMessageTransformStream = utils.clientInputTransformStream<I>(
-      method,
-      refreshingTimer,
-    );
+    const inputMessageTransformStream =
+      utils.clientInputTransformStream<I>(method);
     const middleware = this.middlewareFactory(
       { signal, timer },
       rpcStream.cancel,

--- a/src/RPCServer.ts
+++ b/src/RPCServer.ts
@@ -297,9 +297,6 @@ class RPCServer {
         // Input generator derived from the forward stream
         const inputGen = async function* (): AsyncIterable<I> {
           for await (const data of forwardStream) {
-            if (ctx.timer.status !== 'settled') {
-              ctx.timer.refresh();
-            }
             yield data.params as I;
           }
         };
@@ -309,7 +306,7 @@ class RPCServer {
         });
         for await (const response of handlerG) {
           if (ctx.timer.status !== 'settled') {
-            ctx.timer.refresh();
+            ctx.timer.cancel(utils.timeoutCancelledReason);
           }
           const responseMessage: JSONRPCResponseResult = {
             jsonrpc: '2.0',


### PR DESCRIPTION
### Description
This PR makes changes that cancel the timeout timers after the initial server-sent message.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #52 

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Apply timeout changes to RPCClient
- [x] 2. Apply timeout changes to RPCServer
- [x] 3. Rewrite tests for new timeouts

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
