### PR TITLE
Renaming of `JSONRPCRequest` and `JSONRPCResponse` Related Types and Better Metadata Type Safety

### DIFF
--- a/src/RPCClient.ts
+++ b/src/RPCClient.ts
@@ -8,7 +8,7 @@ import type {
   JSONRPCRequest,
   JSONRPCRequestMessage,
   JSONRPCResponse,
-  JSONRPCResponseResult,
+  JSONRPCResponseSuccess,
   JSONValue,
   MapCallers,
   MiddlewareFactory,
@@ -466,7 +466,7 @@ class RPCClient<M extends ClientManifest> {
         // Ignore any errors here, we only care that it ended
         .catch(() => {});
       const tempReader = headTransformStream.readable.getReader();
-      let leadingMessage: JSONRPCResponseResult;
+      let leadingMessage: JSONRPCResponseSuccess;
       try {
         const message = await Promise.race([tempReader.read(), abortProm.p]);
         const messageValue = message.value as JSONRPCResponse;

--- a/src/RPCServer.ts
+++ b/src/RPCServer.ts
@@ -3,11 +3,11 @@ import type {
   IdGen,
   ClientHandlerImplementation,
   DuplexHandlerImplementation,
-  JSONRPCError,
+  JSONRPCResponseError,
   JSONRPCRequest,
   JSONRPCResponse,
-  JSONRPCResponseError,
-  JSONRPCResponseResult,
+  JSONRPCResponseFailed,
+  JSONRPCResponseSuccess,
   ServerManifest,
   RawHandlerImplementation,
   ServerHandlerImplementation,
@@ -66,7 +66,7 @@ class RPCServer {
     JSONRPCRequest,
     Uint8Array,
     Uint8Array,
-    JSONRPCResponseResult
+    JSONRPCResponseSuccess
   >;
   // Function to register a callback for timeout
   public registerOnTimeoutCallback(callback: () => void) {
@@ -98,7 +98,7 @@ class RPCServer {
       JSONRPCRequest,
       Uint8Array,
       Uint8Array,
-      JSONRPCResponseResult
+      JSONRPCResponseSuccess
     >;
     timeoutTime?: number;
     logger?: Logger;
@@ -308,7 +308,7 @@ class RPCServer {
           if (ctx.timer.status !== 'settled') {
             ctx.timer.cancel(utils.timeoutCancelledReason);
           }
-          const responseMessage: JSONRPCResponseResult = {
+          const responseMessage: JSONRPCResponseSuccess = {
             jsonrpc: '2.0',
             result: response,
             id,
@@ -328,12 +328,12 @@ class RPCServer {
             controller.enqueue(value);
           } catch (e) {
             try {
-              const rpcError: JSONRPCError = {
-                code: errors.JSONRPCErrorCode.RPCRemote,
+              const rpcError: JSONRPCResponseError = {
+                code: errors.JSONRPCResponseErrorCode.RPCRemote,
                 message: e.message,
                 data: this.fromError(e),
               };
-              const rpcErrorMessage: JSONRPCResponseError = {
+              const rpcErrorMessage: JSONRPCResponseFailed = {
                 jsonrpc: '2.0',
                 error: rpcError,
                 id,
@@ -603,12 +603,12 @@ class RPCServer {
         );
       } catch (e) {
         try {
-          const rpcError: JSONRPCError = {
-            code: errors.JSONRPCErrorCode.RPCRemote,
+          const rpcError: JSONRPCResponseError = {
+            code: errors.JSONRPCResponseErrorCode.RPCRemote,
             message: e.message,
             data: this.fromError(e),
           };
-          const rpcErrorMessage: JSONRPCResponseError = {
+          const rpcErrorMessage: JSONRPCResponseFailed = {
             jsonrpc: '2.0',
             error: rpcError,
             id,
@@ -634,7 +634,7 @@ class RPCServer {
 
       if (leadingResult !== undefined) {
         // Writing leading metadata
-        const leadingMessage: JSONRPCResponseResult = {
+        const leadingMessage: JSONRPCResponseSuccess = {
           jsonrpc: '2.0',
           result: leadingResult,
           id,

--- a/src/callers/Caller.ts
+++ b/src/callers/Caller.ts
@@ -1,13 +1,13 @@
 import type {
   HandlerType,
   JSONObject,
-  JSONRPCParams,
-  JSONRPCResult,
+  JSONRPCRequestParams,
+  JSONRPCResponseResult,
 } from '../types';
 
 abstract class Caller<
-  Input extends JSONObject = JSONRPCParams,
-  Output extends JSONObject = JSONRPCResult,
+  Input extends JSONObject = JSONRPCRequestParams,
+  Output extends JSONObject = JSONRPCResponseResult,
 > {
   protected _inputType: Input;
   protected _outputType: Output;

--- a/src/callers/ClientCaller.ts
+++ b/src/callers/ClientCaller.ts
@@ -1,9 +1,13 @@
-import type { JSONObject, JSONRPCParams, JSONRPCResult } from '../types';
+import type {
+  JSONObject,
+  JSONRPCRequestParams,
+  JSONRPCResponseResult,
+} from '../types';
 import Caller from './Caller';
 
 class ClientCaller<
-  Input extends JSONObject = JSONRPCParams,
-  Output extends JSONObject = JSONRPCResult,
+  Input extends JSONObject = JSONRPCRequestParams,
+  Output extends JSONObject = JSONRPCResponseResult,
 > extends Caller<Input, Output> {
   public type: 'CLIENT' = 'CLIENT' as const;
 }

--- a/src/callers/DuplexCaller.ts
+++ b/src/callers/DuplexCaller.ts
@@ -1,9 +1,13 @@
-import type { JSONObject, JSONRPCParams, JSONRPCResult } from '../types';
+import type {
+  JSONObject,
+  JSONRPCRequestParams,
+  JSONRPCResponseResult,
+} from '../types';
 import Caller from './Caller';
 
 class DuplexCaller<
-  Input extends JSONObject = JSONRPCParams,
-  Output extends JSONObject = JSONRPCResult,
+  Input extends JSONObject = JSONRPCRequestParams,
+  Output extends JSONObject = JSONRPCResponseResult,
 > extends Caller<Input, Output> {
   public type: 'DUPLEX' = 'DUPLEX' as const;
 }

--- a/src/callers/ServerCaller.ts
+++ b/src/callers/ServerCaller.ts
@@ -1,9 +1,13 @@
-import type { JSONObject, JSONRPCParams, JSONRPCResult } from '../types';
+import type {
+  JSONObject,
+  JSONRPCRequestParams,
+  JSONRPCResponseResult,
+} from '../types';
 import Caller from './Caller';
 
 class ServerCaller<
-  Input extends JSONObject = JSONRPCParams,
-  Output extends JSONObject = JSONRPCResult,
+  Input extends JSONObject = JSONRPCRequestParams,
+  Output extends JSONObject = JSONRPCResponseResult,
 > extends Caller<Input, Output> {
   public type: 'SERVER' = 'SERVER' as const;
 }

--- a/src/callers/UnaryCaller.ts
+++ b/src/callers/UnaryCaller.ts
@@ -1,9 +1,13 @@
-import type { JSONObject, JSONRPCParams, JSONRPCResult } from '../types';
+import type {
+  JSONObject,
+  JSONRPCRequestParams,
+  JSONRPCResponseResult,
+} from '../types';
 import Caller from './Caller';
 
 class UnaryCaller<
-  Input extends JSONObject = JSONRPCParams,
-  Output extends JSONObject = JSONRPCResult,
+  Input extends JSONObject = JSONRPCRequestParams,
+  Output extends JSONObject = JSONRPCResponseResult,
 > extends Caller<Input, Output> {
   public type: 'UNARY' = 'UNARY' as const;
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,5 @@
 import type { Class } from '@matrixai/errors';
-import type { JSONRPCError, JSONValue, POJO } from './types';
+import type { JSONRPCResponseError, JSONValue, POJO } from './types';
 import { AbstractError } from '@matrixai/errors';
 
 class ErrorRPC<T> extends AbstractError<T> {
@@ -71,7 +71,7 @@ abstract class ErrorRPCProtocol<T> extends ErrorRPC<T> {
    * The return type WILL NOT include cause, this will be handled by `fromError`
    * @returns
    */
-  public toJSON(): JSONRPCError {
+  public toJSON(): JSONRPCResponseError {
     return {
       code: this.code,
       message: this.message,
@@ -86,52 +86,52 @@ abstract class ErrorRPCProtocol<T> extends ErrorRPC<T> {
 
 class ErrorRPCParse<T> extends ErrorRPCProtocol<T> {
   static description = 'Failed to parse Buffer stream';
-  code = JSONRPCErrorCode.ParseError;
+  code = JSONRPCResponseErrorCode.ParseError;
 }
 
 class ErrorRPCInvalidParams<T> extends ErrorRPCProtocol<T> {
   static description = 'Invalid paramaters provided to RPC';
-  code = JSONRPCErrorCode.InvalidParams;
+  code = JSONRPCResponseErrorCode.InvalidParams;
 }
 
 class ErrorRPCStopping<T> extends ErrorRPCProtocol<T> {
   static description = 'RPC is stopping';
-  code = JSONRPCErrorCode.RPCStopping;
+  code = JSONRPCResponseErrorCode.RPCStopping;
 }
 
 class ErrorMissingCaller<T> extends ErrorRPCProtocol<T> {
   static description = 'Caller is missing';
-  code = JSONRPCErrorCode.MissingCaller;
+  code = JSONRPCResponseErrorCode.MissingCaller;
 }
 class ErrorMissingHeader<T> extends ErrorRPCProtocol<T> {
   static description = 'Header information is missing';
-  code = JSONRPCErrorCode.MissingHeader;
+  code = JSONRPCResponseErrorCode.MissingHeader;
 }
 
 class ErrorHandlerAborted<T> extends ErrorRPCProtocol<T> {
   static description = 'Handler Aborted Stream';
-  code = JSONRPCErrorCode.HandlerAborted;
+  code = JSONRPCResponseErrorCode.HandlerAborted;
 }
 
 class ErrorRPCMessageLength<T> extends ErrorRPCProtocol<T> {
   static description = 'RPC Message exceeds maximum size';
-  code = JSONRPCErrorCode.RPCMessageLength;
+  code = JSONRPCResponseErrorCode.RPCMessageLength;
 }
 
 class ErrorRPCMissingResponse<T> extends ErrorRPCProtocol<T> {
   static description = 'Stream ended before response';
-  code = JSONRPCErrorCode.RPCMissingResponse;
+  code = JSONRPCResponseErrorCode.RPCMissingResponse;
 }
 
 class ErrorRPCOutputStreamError<T> extends ErrorRPCProtocol<T> {
   static description = 'Output stream failed, unable to send data';
-  code = JSONRPCErrorCode.RPCOutputStreamError;
+  code = JSONRPCResponseErrorCode.RPCOutputStreamError;
 }
 
 class ErrorRPCRemote<T> extends ErrorRPCProtocol<T> {
   static description = 'Remote error from RPC call';
   static message: string = 'The server responded with an error';
-  code = JSONRPCErrorCode.RPCRemote;
+  code = JSONRPCResponseErrorCode.RPCRemote;
   metadata: JSONValue;
 
   constructor(
@@ -150,13 +150,13 @@ class ErrorRPCRemote<T> extends ErrorRPCProtocol<T> {
 
 class ErrorRPCStreamEnded<T> extends ErrorRPCProtocol<T> {
   static description = 'Handled stream has ended';
-  code = JSONRPCErrorCode.RPCStreamEnded;
+  code = JSONRPCResponseErrorCode.RPCStreamEnded;
 }
 
 class ErrorRPCTimedOut<T> extends ErrorRPCProtocol<T> {
   static description = 'RPC handler has timed out';
-  code = JSONRPCErrorCode.RPCTimedOut;
-  public toJSON(): JSONRPCError {
+  code = JSONRPCResponseErrorCode.RPCTimedOut;
+  public toJSON(): JSONRPCResponseError {
     const json = super.toJSON();
     if (typeof json === 'object' && !Array.isArray(json)) {
       (json as POJO).type = this.constructor.name;
@@ -167,33 +167,33 @@ class ErrorRPCTimedOut<T> extends ErrorRPCProtocol<T> {
 
 class ErrorUtilsUndefinedBehaviour<T> extends ErrorRPCProtocol<T> {
   static description = 'You should never see this error';
-  code = JSONRPCErrorCode.MethodNotFound;
+  code = JSONRPCResponseErrorCode.MethodNotFound;
 }
 
 class ErrorRPCMethodNotImplemented<T> extends ErrorRPCProtocol<T> {
   static description =
     'This abstract method must be implemented in a derived class';
-  code = JSONRPCErrorCode.MethodNotFound;
+  code = JSONRPCResponseErrorCode.MethodNotFound;
 }
 
 class ErrorRPCConnectionLocal<T> extends ErrorRPCProtocol<T> {
   static description = 'RPC Connection local error';
-  code = JSONRPCErrorCode.RPCConnectionLocal;
+  code = JSONRPCResponseErrorCode.RPCConnectionLocal;
 }
 
 class ErrorRPCConnectionPeer<T> extends ErrorRPCProtocol<T> {
   static description = 'RPC Connection peer error';
-  code = JSONRPCErrorCode.RPCConnectionPeer;
+  code = JSONRPCResponseErrorCode.RPCConnectionPeer;
 }
 
 class ErrorRPCConnectionKeepAliveTimeOut<T> extends ErrorRPCProtocol<T> {
   static description = 'RPC Connection keep alive timeout';
-  code = JSONRPCErrorCode.RPCConnectionKeepAliveTimeOut;
+  code = JSONRPCResponseErrorCode.RPCConnectionKeepAliveTimeOut;
 }
 
 class ErrorRPCConnectionInternal<T> extends ErrorRPCProtocol<T> {
   static description = 'RPC Connection internal error';
-  code = JSONRPCErrorCode.RPCConnectionInternal;
+  code = JSONRPCResponseErrorCode.RPCConnectionInternal;
 }
 
 class ErrorRPCUnknown<T> extends ErrorRPCProtocol<T> {
@@ -201,7 +201,7 @@ class ErrorRPCUnknown<T> extends ErrorRPCProtocol<T> {
   code = 0;
 }
 
-const enum JSONRPCErrorCode {
+const enum JSONRPCResponseErrorCode {
   ParseError = -32700,
   InvalidRequest = -32600,
   MethodNotFound = -32601,
@@ -225,24 +225,24 @@ const enum JSONRPCErrorCode {
 }
 
 const rpcProtocolErrors = {
-  [JSONRPCErrorCode.RPCRemote]: ErrorRPCRemote,
-  [JSONRPCErrorCode.RPCStopping]: ErrorRPCStopping,
-  [JSONRPCErrorCode.RPCMessageLength]: ErrorRPCMessageLength,
-  [JSONRPCErrorCode.ParseError]: ErrorRPCParse,
-  [JSONRPCErrorCode.InvalidParams]: ErrorRPCInvalidParams,
-  [JSONRPCErrorCode.HandlerNotFound]: ErrorRPCHandlerFailed,
-  [JSONRPCErrorCode.RPCMissingResponse]: ErrorRPCMissingResponse,
-  [JSONRPCErrorCode.RPCOutputStreamError]: ErrorRPCOutputStreamError,
-  [JSONRPCErrorCode.RPCTimedOut]: ErrorRPCTimedOut,
-  [JSONRPCErrorCode.RPCStreamEnded]: ErrorRPCStreamEnded,
-  [JSONRPCErrorCode.RPCConnectionLocal]: ErrorRPCConnectionLocal,
-  [JSONRPCErrorCode.RPCConnectionPeer]: ErrorRPCConnectionPeer,
-  [JSONRPCErrorCode.RPCConnectionKeepAliveTimeOut]:
+  [JSONRPCResponseErrorCode.RPCRemote]: ErrorRPCRemote,
+  [JSONRPCResponseErrorCode.RPCStopping]: ErrorRPCStopping,
+  [JSONRPCResponseErrorCode.RPCMessageLength]: ErrorRPCMessageLength,
+  [JSONRPCResponseErrorCode.ParseError]: ErrorRPCParse,
+  [JSONRPCResponseErrorCode.InvalidParams]: ErrorRPCInvalidParams,
+  [JSONRPCResponseErrorCode.HandlerNotFound]: ErrorRPCHandlerFailed,
+  [JSONRPCResponseErrorCode.RPCMissingResponse]: ErrorRPCMissingResponse,
+  [JSONRPCResponseErrorCode.RPCOutputStreamError]: ErrorRPCOutputStreamError,
+  [JSONRPCResponseErrorCode.RPCTimedOut]: ErrorRPCTimedOut,
+  [JSONRPCResponseErrorCode.RPCStreamEnded]: ErrorRPCStreamEnded,
+  [JSONRPCResponseErrorCode.RPCConnectionLocal]: ErrorRPCConnectionLocal,
+  [JSONRPCResponseErrorCode.RPCConnectionPeer]: ErrorRPCConnectionPeer,
+  [JSONRPCResponseErrorCode.RPCConnectionKeepAliveTimeOut]:
     ErrorRPCConnectionKeepAliveTimeOut,
-  [JSONRPCErrorCode.RPCConnectionInternal]: ErrorRPCConnectionInternal,
-  [JSONRPCErrorCode.MissingHeader]: ErrorMissingHeader,
-  [JSONRPCErrorCode.HandlerAborted]: ErrorRPCHandlerFailed,
-  [JSONRPCErrorCode.MissingCaller]: ErrorMissingCaller,
+  [JSONRPCResponseErrorCode.RPCConnectionInternal]: ErrorRPCConnectionInternal,
+  [JSONRPCResponseErrorCode.MissingHeader]: ErrorMissingHeader,
+  [JSONRPCResponseErrorCode.HandlerAborted]: ErrorRPCHandlerFailed,
+  [JSONRPCResponseErrorCode.MissingCaller]: ErrorMissingCaller,
 };
 
 export {
@@ -273,6 +273,6 @@ export {
   ErrorRPCCallerFailed,
   ErrorMissingCaller,
   ErrorRPCUnknown,
-  JSONRPCErrorCode,
+  JSONRPCResponseErrorCode,
   rpcProtocolErrors,
 };

--- a/src/handlers/ClientHandler.ts
+++ b/src/handlers/ClientHandler.ts
@@ -1,8 +1,8 @@
 import type {
   ContainerType,
   JSONValue,
-  JSONRPCParams,
-  JSONRPCResult,
+  JSONRPCRequestParams,
+  JSONRPCResponseResult,
 } from '../types';
 import type { ContextTimed } from '@matrixai/contexts';
 import Handler from './Handler';
@@ -10,8 +10,8 @@ import { ErrorRPCMethodNotImplemented } from '../errors';
 
 abstract class ClientHandler<
   Container extends ContainerType = ContainerType,
-  Input extends JSONRPCParams = JSONRPCParams,
-  Output extends JSONRPCResult = JSONRPCResult,
+  Input extends JSONRPCRequestParams = JSONRPCRequestParams,
+  Output extends JSONRPCResponseResult = JSONRPCResponseResult,
 > extends Handler<Container, Input, Output> {
   public async handle(
     /* eslint-disable */

--- a/src/handlers/DuplexHandler.ts
+++ b/src/handlers/DuplexHandler.ts
@@ -1,8 +1,8 @@
 import type {
   ContainerType,
   JSONValue,
-  JSONRPCParams,
-  JSONRPCResult,
+  JSONRPCRequestParams,
+  JSONRPCResponseResult,
 } from '../types';
 import type { ContextTimed } from '@matrixai/contexts';
 import Handler from './Handler';
@@ -10,8 +10,8 @@ import { ErrorRPCMethodNotImplemented } from '../errors';
 
 abstract class DuplexHandler<
   Container extends ContainerType = ContainerType,
-  Input extends JSONRPCParams = JSONRPCParams,
-  Output extends JSONRPCResult = JSONRPCResult,
+  Input extends JSONRPCRequestParams = JSONRPCRequestParams,
+  Output extends JSONRPCResponseResult = JSONRPCResponseResult,
 > extends Handler<Container, Input, Output> {
   /**
    * Note that if the output has an error, the handler will not see this as an

--- a/src/handlers/Handler.ts
+++ b/src/handlers/Handler.ts
@@ -1,8 +1,12 @@
-import type { ContainerType, JSONRPCParams, JSONRPCResult } from '../types';
+import type {
+  ContainerType,
+  JSONRPCRequestParams,
+  JSONRPCResponseResult,
+} from '../types';
 abstract class Handler<
   Container extends ContainerType = ContainerType,
-  Input extends JSONRPCParams = JSONRPCParams,
-  Output extends JSONRPCResult = JSONRPCResult,
+  Input extends JSONRPCRequestParams = JSONRPCRequestParams,
+  Output extends JSONRPCResponseResult = JSONRPCResponseResult,
 > {
   // These are used to distinguish the handlers in the type system.
   // Without these the map types can't tell the types of handlers apart.

--- a/src/handlers/RawHandler.ts
+++ b/src/handlers/RawHandler.ts
@@ -3,7 +3,7 @@ import type { ReadableStream } from 'stream/web';
 import type {
   ContainerType,
   JSONRPCRequest,
-  JSONRPCResult,
+  JSONRPCResponseResult,
   JSONValue,
 } from '../types';
 import Handler from './Handler';
@@ -19,7 +19,7 @@ abstract class RawHandler<
     meta: Record<string, JSONValue> | undefined,
     ctx: ContextTimed,
     /* eslint-disable */
-  ): Promise<[JSONRPCResult, ReadableStream<Uint8Array>]> {
+  ): Promise<[JSONRPCResponseResult, ReadableStream<Uint8Array>]> {
     throw new ErrorRPCMethodNotImplemented('This method must be overridden');
   }
 }

--- a/src/handlers/ServerHandler.ts
+++ b/src/handlers/ServerHandler.ts
@@ -2,16 +2,16 @@ import type { ContextTimed } from '@matrixai/contexts';
 import type {
   ContainerType,
   JSONValue,
-  JSONRPCParams,
-  JSONRPCResult,
+  JSONRPCRequestParams,
+  JSONRPCResponseResult,
 } from '../types';
 import Handler from './Handler';
 import { ErrorRPCMethodNotImplemented } from '../errors';
 
 abstract class ServerHandler<
   Container extends ContainerType = ContainerType,
-  Input extends JSONRPCParams = JSONRPCParams,
-  Output extends JSONRPCResult = JSONRPCResult,
+  Input extends JSONRPCRequestParams = JSONRPCRequestParams,
+  Output extends JSONRPCResponseResult = JSONRPCResponseResult,
 > extends Handler<Container, Input, Output> {
   public async *handle(
     /* eslint-disable */

--- a/src/handlers/UnaryHandler.ts
+++ b/src/handlers/UnaryHandler.ts
@@ -2,16 +2,16 @@ import type { ContextTimed } from '@matrixai/contexts';
 import type {
   ContainerType,
   JSONValue,
-  JSONRPCParams,
-  JSONRPCResult,
+  JSONRPCRequestParams,
+  JSONRPCResponseResult,
 } from '../types';
 import Handler from './Handler';
 import { ErrorRPCMethodNotImplemented } from '../errors';
 
 abstract class UnaryHandler<
   Container extends ContainerType = ContainerType,
-  Input extends JSONRPCParams = JSONRPCParams,
-  Output extends JSONRPCResult = JSONRPCResult,
+  Input extends JSONRPCRequestParams = JSONRPCRequestParams,
+  Output extends JSONRPCResponseResult = JSONRPCResponseResult,
 > extends Handler<Container, Input, Output> {
   public async handle(
     /* eslint-disable */

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@ import type {
   JSONRPCMessage,
   JSONRPCRequest,
   JSONRPCResponse,
-  JSONRPCResponseResult,
+  JSONRPCResponseSuccess,
   MiddlewareFactory,
   JSONValue,
 } from './types';
@@ -188,8 +188,8 @@ function defaultServerMiddlewareWrapper(
       parserBufferByteLimit,
     );
     const outputTransformStream = new TransformStream<
-      JSONRPCResponseResult,
-      JSONRPCResponseResult
+      JSONRPCResponseSuccess,
+      JSONRPCResponseSuccess
     >();
 
     const middleMiddleware = middlewareFactory(ctx, cancel, meta);

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,23 +114,40 @@ type JSONRPCRequestMetadata = Partial<{
   timeout: number | null;
 }>;
 
-type JSONRPCRequestParams<T extends JSONObject = JSONObject> = {
+/**
+ * `T` is the the params you want to specify.
+ *
+ * `M` is the metadata you want to specify.
+ *
+ * Metadata can also be specified on `T.metadata`
+ */
+type JSONRPCRequestParams<
+  T extends JSONObject = JSONObject,
+  M extends JSONObject = JSONObject,
+> = {
   metadata?: JSONObject &
-    JSONRPCResponseMetadata &
-    Omit<T['metadata'], keyof JSONRPCResponseMetadata>;
+    JSONRPCRequestMetadata &
+    Omit<T['metadata'] & M, keyof JSONRPCRequestMetadata>;
 } & Omit<T, 'metadata'>;
 
 type JSONRPCResponseMetadata = Partial<{
   timeout: number | null;
 }>;
 
+/**
+ * `T` is the the result you want to specify.
+ *
+ * `M` is the metadata you want to specify.
+ *
+ * Metadata can also be specified on `T.metadata`
+ */
 type JSONRPCResponseResult<
   T extends JSONObject = JSONObject,
   M extends JSONObject = JSONObject,
 > = {
   metadata?: JSONObject &
     JSONRPCResponseMetadata &
-    Omit<M, keyof JSONRPCResponseMetadata>;
+    Omit<T['metadata'] & M, keyof JSONRPCResponseMetadata>;
 } & Omit<T, 'metadata'>;
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ type JSONRPCRequestMessage<T extends JSONObject = JSONObject> = {
    * A Structured value that holds the parameter values to be used during the invocation of the method.
    *  This member MAY be omitted.
    */
-  params?: JSONRPCParams<T>;
+  params?: JSONRPCRequestParams<T>;
   /**
    * An identifier established by the Client that MUST contain a String, Number, or NULL value if included.
    *  If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [1] and Numbers
@@ -59,14 +59,14 @@ type JSONRPCRequestNotification<T extends JSONObject = JSONObject> = {
    * A Structured value that holds the parameter values to be used during the invocation of the method.
    *  This member MAY be omitted.
    */
-  params: JSONRPCParams<T>;
+  params: JSONRPCRequestParams<T>;
 };
 
 /**
  * This is the JSON RPC response result object. It contains the response data for a
  * corresponding request.
  */
-type JSONRPCResponseResult<T extends JSONObject = JSONObject> = {
+type JSONRPCResponseSuccess<T extends JSONObject = JSONObject> = {
   /**
    * A String specifying the version of the JSON-RPC protocol. MUST be exactly "2.0".
    */
@@ -76,7 +76,7 @@ type JSONRPCResponseResult<T extends JSONObject = JSONObject> = {
    *  This member MUST NOT exist if there was an error invoking the method.
    *  The value of this member is determined by the method invoked on the Server.
    */
-  result: JSONRPCResult<T>;
+  result: JSONRPCResponseResult<T>;
   /**
    * This member is REQUIRED.
    *  It MUST be the same as the value of the id member in the Request Object.
@@ -90,7 +90,7 @@ type JSONRPCResponseResult<T extends JSONObject = JSONObject> = {
  * This is the JSON RPC response Error object. It contains any errors that have
  * occurred when responding to a request.
  */
-type JSONRPCResponseError = {
+type JSONRPCResponseFailed = {
   /**
    * A String specifying the version of the JSON-RPC protocol. MUST be exactly "2.0".
    */
@@ -100,7 +100,7 @@ type JSONRPCResponseError = {
    *  This member MUST NOT exist if there was no error triggered during invocation.
    *  The value for this member MUST be an Object as defined in section 5.1.
    */
-  error: JSONRPCError;
+  error: JSONRPCResponseError;
   /**
    * This member is REQUIRED.
    *  It MUST be the same as the value of the id member in the Request Object.
@@ -110,26 +110,33 @@ type JSONRPCResponseError = {
   id: string | number | null;
 };
 
-type JSONRPCParams<T extends JSONObject = JSONObject> = {
-  metadata?: {
-    [Key: string]: JSONValue;
-  } & Partial<{
-    timeout: number | null;
-  }>;
-} & T;
+type JSONRPCRequestMetadata = Partial<{
+  timeout: number | null;
+}>;
 
-type JSONRPCResult<T extends JSONObject = JSONObject> = {
-  metadata?: {
-    [Key: string]: JSONValue;
-  } & Partial<{
-    timeout: number | null;
-  }>;
-} & T;
+type JSONRPCRequestParams<T extends JSONObject = JSONObject> = {
+  metadata?: JSONObject &
+    JSONRPCResponseMetadata &
+    Omit<T['metadata'], keyof JSONRPCResponseMetadata>;
+} & Omit<T, 'metadata'>;
+
+type JSONRPCResponseMetadata = Partial<{
+  timeout: number | null;
+}>;
+
+type JSONRPCResponseResult<
+  T extends JSONObject = JSONObject,
+  M extends JSONObject = JSONObject,
+> = {
+  metadata?: JSONObject &
+    JSONRPCResponseMetadata &
+    Omit<M, keyof JSONRPCResponseMetadata>;
+} & Omit<T, 'metadata'>;
 
 /**
- * This is a JSON RPC error object, it encodes the error data for the JSONRPCResponseError object.
+ * This is a JSON RPC error object, it encodes the error data for the JSONRPCResponseFailed object.
  */
-type JSONRPCError = {
+type JSONRPCResponseError = {
   /**
    * A Number that indicates the error type that occurred.
    *  This MUST be an integer.
@@ -160,8 +167,8 @@ type JSONRPCRequest<T extends JSONObject = JSONObject> =
  * This is a JSON RPC response object. It can be a response result or error.
  */
 type JSONRPCResponse<T extends JSONObject = JSONObject> =
-  | JSONRPCResponseResult<T>
-  | JSONRPCResponseError;
+  | JSONRPCResponseSuccess<T>
+  | JSONRPCResponseFailed;
 
 /**
  * This is a JSON RPC Message object. This is top level and can be any kind of
@@ -373,11 +380,13 @@ export type {
   IdGen,
   JSONRPCRequestMessage,
   JSONRPCRequestNotification,
+  JSONRPCResponseSuccess,
+  JSONRPCResponseFailed,
+  JSONRPCRequestMetadata,
+  JSONRPCRequestParams,
+  JSONRPCResponseMetadata,
   JSONRPCResponseResult,
   JSONRPCResponseError,
-  JSONRPCParams,
-  JSONRPCResult,
-  JSONRPCError,
   JSONRPCRequest,
   JSONRPCResponse,
   JSONRPCMessage,

--- a/tests/RPC.test.ts
+++ b/tests/RPC.test.ts
@@ -1,9 +1,9 @@
 import type {
   ContainerType,
   JSONObject,
-  JSONRPCParams,
+  JSONRPCRequestParams,
   JSONRPCRequest,
-  JSONRPCResult,
+  JSONRPCResponseResult,
 } from '@/types';
 import type { ReadableStream } from 'stream/web';
 import type { JSONValue, IdGen } from '@/types';
@@ -402,8 +402,8 @@ describe('RPC', () => {
 
       class TestMethod extends UnaryHandler {
         public handle = async (
-          input: JSONRPCParams,
-        ): Promise<JSONRPCResult> => {
+          input: JSONRPCRequestParams,
+        ): Promise<JSONRPCResponseResult> => {
           return input;
         };
       }


### PR DESCRIPTION
### Description
This PR renames `JSONRPCRequest`and `JSONRPCResponse` related types and implements better type-safety on metadata types to allow for users to provide their own metadata properties without overriding defaults like `metadata.timeout`

### Issues Fixed
None.

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Rename types
    - [x] `JSONRPCResponseResult` to `JSONRPCResponseSuccess`
    - [x] `JSONRPCResponseError` to `JSONRPCResponseFailed`
    - [x] `JSONRPCResult` to `JSONRPCResponseResult` 
    - [x] `JSONRPCParams` to `JSONRPCRequestParams` 
    - [x] JSONRPCError` to `JSONRPCResponseError`
- [x] 2. Change `JSONRPCRequestParams` to allow for specifying custom metadata without overriding defaults
- [x] 3. Change `JSONRPCResponseResult` to allow for specifying custom metadata without overriding defaults

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build
