### PR TITLE
Define `message` for non-`Error` errors

### DIFF
--- a/src/RPCServer.ts
+++ b/src/RPCServer.ts
@@ -58,7 +58,14 @@ function composeMessage(error: unknown): string {
   if (typeof error === 'object' && error?.constructor?.name != null) {
     return `Non-error object ${error.constructor.name} was thrown`;
   }
-  return `Non-error value ${error} was thrown`;
+  // If an object is not serialisable (for example, Object.create(null)), then
+  // an error would be raised when trying to convert it to a string. In that
+  // case, simply avoid serialising the error.
+  try {
+    return `Non-error value ${error} was thrown`;
+  } catch (e) {
+    return 'Non-error value was thrown'
+  }
 }
 
 /**

--- a/src/RPCServer.ts
+++ b/src/RPCServer.ts
@@ -37,34 +37,36 @@ import * as events from './events';
 
 const cleanupReason = Symbol('CleanupReason');
 
-function composeMessage(error: unknown): string {
-  if (
-    typeof error === 'boolean' ||
-    typeof error === 'number' ||
-    typeof error === 'string' ||
-    typeof error === 'bigint' ||
-    typeof error === 'symbol'
-  ) {
-    return `Non-error literal ${String(error)} was thrown`;
+function composeErrorMessage(error: unknown): string {
+  switch (typeof error) {
+    case 'boolean':
+    case 'number':
+    case 'string':
+    case 'bigint':
+    case 'symbol':
+      return `Non-error literal ${String(error)} was thrown`;
+    case 'object':
+      // Let the fallback handler catch null values.
+      if (error == null) break;
+      // If we have an error message defined, then return that.
+      if ('message' in error && typeof error.message === 'string') {
+        return error.message;
+      }
+      // If present, mention the constructor name in the message.
+      if (error.constructor?.name != null) {
+        return `Non-error object ${error.constructor.name} was thrown`;
+      }
+      // Any other values should be handled by the fallback handler.
+      break;
   }
-  if (
-    typeof error === 'object' &&
-    error != null &&
-    'message' in error &&
-    error.message != null
-  ) {
-    return String(error.message);
-  }
-  if (typeof error === 'object' && error?.constructor?.name != null) {
-    return `Non-error object ${error.constructor.name} was thrown`;
-  }
-  // If an object is not serialisable (for example, Object.create(null)), then
-  // an error would be raised when trying to convert it to a string. In that
-  // case, simply avoid serialising the error.
+
+  // Handle cases where the error is not serialisable, like objects created
+  // using Object.create(null). Trying to serialise this throws a TypeError.
   try {
-    return `Non-error value ${error} was thrown`;
+    return `Non-error value ${String(error)} was thrown`;
   } catch (e) {
-    return 'Non-error value was thrown'
+    if (e instanceof TypeError) return 'Non-error value was thrown';
+    else throw e;
   }
 }
 
@@ -358,7 +360,7 @@ class RPCServer {
             try {
               const rpcError: JSONRPCResponseError = {
                 code: errors.JSONRPCResponseErrorCode.RPCRemote,
-                message: composeMessage(e),
+                message: composeErrorMessage(e),
                 data: this.fromError(e),
               };
               const rpcErrorMessage: JSONRPCResponseFailed = {
@@ -630,7 +632,7 @@ class RPCServer {
         try {
           const rpcError: JSONRPCResponseError = {
             code: errors.JSONRPCResponseErrorCode.RPCRemote,
-            message: composeMessage(e),
+            message: composeErrorMessage(e),
             data: this.fromError(e),
           };
           const rpcErrorMessage: JSONRPCResponseFailed = {

--- a/src/RPCServer.ts
+++ b/src/RPCServer.ts
@@ -37,6 +37,30 @@ import * as events from './events';
 
 const cleanupReason = Symbol('CleanupReason');
 
+function composeMessage(error: unknown): string {
+  if (
+    typeof error === 'boolean' ||
+    typeof error === 'number' ||
+    typeof error === 'string' ||
+    typeof error === 'bigint' ||
+    typeof error === 'symbol'
+  ) {
+    return `Non-error literal ${String(error)} was thrown`;
+  }
+  if (
+    typeof error === 'object' &&
+    error != null &&
+    'message' in error &&
+    error.message != null
+  ) {
+    return String(error.message);
+  }
+  if (typeof error === 'object' && error?.constructor?.name != null) {
+    return `Non-error object ${error.constructor.name} was thrown`;
+  }
+  return `Non-error value ${error} was thrown`;
+}
+
 /**
  * You must provide a error handler `addEventListener('error')`.
  * Otherwise errors will just be ignored.
@@ -327,7 +351,7 @@ class RPCServer {
             try {
               const rpcError: JSONRPCResponseError = {
                 code: errors.JSONRPCResponseErrorCode.RPCRemote,
-                message: e.message ?? e.constructor.name,
+                message: composeMessage(e),
                 data: this.fromError(e),
               };
               const rpcErrorMessage: JSONRPCResponseFailed = {
@@ -599,7 +623,7 @@ class RPCServer {
         try {
           const rpcError: JSONRPCResponseError = {
             code: errors.JSONRPCResponseErrorCode.RPCRemote,
-            message: e.message ?? e.constructor.name,
+            message: composeMessage(e),
             data: this.fromError(e),
           };
           const rpcErrorMessage: JSONRPCResponseFailed = {

--- a/src/RPCServer.ts
+++ b/src/RPCServer.ts
@@ -327,7 +327,7 @@ class RPCServer {
             try {
               const rpcError: JSONRPCResponseError = {
                 code: errors.JSONRPCResponseErrorCode.RPCRemote,
-                message: e.message,
+                message: e.message ?? e.constructor.name,
                 data: this.fromError(e),
               };
               const rpcErrorMessage: JSONRPCResponseFailed = {
@@ -599,7 +599,7 @@ class RPCServer {
         try {
           const rpcError: JSONRPCResponseError = {
             code: errors.JSONRPCResponseErrorCode.RPCRemote,
-            message: e.message,
+            message: e.message ?? e.constructor.name,
             data: this.fromError(e),
           };
           const rpcErrorMessage: JSONRPCResponseFailed = {


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->

If a non-`Error` error is thrown from within a RPC handler, the `message` field would be undefined. This would result in the `message` field (which is expected to be present) be omitted, breaking the parsing step.

This PR addresses that by wrapping that in a nicer message. For example, if we do `throw 123`, the message becomes `'Non-error class Number was thrown'`. If we do `throw new ReadableStream()`, then the message becomes `'Non-error class ReadableStream was thrown'`. You get the idea.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Relates to PR https://github.com/MatrixAI/Polykey/pull/838

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. If the message does not exist, substitute it with something else
- [x] 2. Run tests to ensure this behaviour is consistent

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [ ] Squash and rebased
* [x] Sanity check the final build
